### PR TITLE
refactor: shared deps module, pipeline decisions, logging improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,89 @@
-# Youtube Subscription to playlist
+# ys2wl — YouTube Subscription to Watch Later
 
-This script will take activity from your subscribers and add them to a playlist.
-If you want to add these videos to the special "watch-later" playlist you need to move them there yourself.  
+Web service that scrapes YouTube subscriptions and routes new videos to
+playlists based on configurable rules.
 
-The script uses pickle to save session betweene runs. it will create a picke file on first run.  
-You need to create a application in youtube to be able to populate this picke-file
-After some time this file will need to be re-created.
+## Quick start
 
-
-example config-file (config.yaml):
-```yaml
-pickle-file: ""                       # File to store access token once authenticated
-credentials-file: ""                  # JSON file with credentials to oAuth2 account
-database-file: ""                     # Location of sqlite database file. Will be created if not exists
-local-json-files: ""                  # JSON file with credentials to oAuth2 account
-compare-distance-number: 0            # Levenstein number to compare difference between existing videos and new
-published-after: ""                   # Only videos from after this date will be added. Timestamp in ISO8601 (YYYY-MM-DDThh:mm:ss.sZ) format
-reprocess-days: ""                    # Amount of days before subscription will be processed again
-youtube-channel: ""                   # Name of your channel with destination playlist
-youtube-playlist: ""                  # Name of playlist to add videos to
-youtube-activity-limit: 0             # How much activity to process per subscription per run
-youtube-subscription-limit: 0         # How many subscriptions to process per run
-youtube-subscription-ignore-file: ""  # File with newline separated list of subscriptions to ignore when processing
-youtube-video-ignore-file: ""         # File with newline separated list of video-ids to ignore when processing
-youtube-words-ignore-file: ""         # File with newline separated list of words to ignore when processing
-youtube-playlist-sleep: 0             # How long to wait between playlist API insert-calls
-youtube-subscription-sleep: 0         # How long to wait between subscription API insert-calls
-youtube-minimum-length: ""            # Minimum length of tracks to add. 1s, 2m, 1h format
-youtube-maximum-length: ""            # Maximum length of tracks to add. 1s, 2m, 1h format
-log-level: ""                         # Set loglevel: debug, info, warning, or error
-log-file: ""                          # File to cast logs to. If you want all output to stdout type "stream"
+```sh
+uv sync --dev
+uv run python -m ys2wl
 ```
 
-## Pre-commit hooks
+Open http://localhost:8080
 
-Install pre-commit and the hook:
+## Configuration
+
+Environment variables with prefix `YS2WL_`. Set via `.env` file, shell env,
+or the web UI at `/ui#config`.
+
+| Variable | Default | Description |
+|---|---|---|
+| `YS2WL_API_PORT` | `8080` | HTTP listen port |
+| `YS2WL_LOG_LEVEL` | `warning` | Log level |
+| `YS2WL_LOG_FILE` | `stream` | Log output (`stream` for stdout) |
+| `YS2WL_PICKLE_FILE` | `credentials.pickle` | OAuth token file path |
+| `YS2WL_CREDENTIALS_FILE` | `client_secret.json` | Google OAuth client JSON |
+| `YS2WL_DATABASE_FILE` | `ys2wl.db` | SQLite database path |
+| `YS2WL_SCHEDULE` | `0 */6 * * *` | Cron expression for pipeline |
+| `YS2WL_COMPARE_DISTANCE` | `80` | Title similarity threshold (0-100) |
+| `YS2WL_REPROCESS_DAYS` | `2` | Days before re-processing a sub |
+| `YS2WL_PLAYLIST_SLEEP` | `10` | Seconds between playlist API inserts |
+| `YS2WL_SUBSCRIPTION_SLEEP` | `30` | Seconds between sub processing |
+| `YS2WL_ACTIVITY_LIMIT` | `0` | Max activities per sub (0=unlimited) |
+| `YS2WL_SUBSCRIPTION_LIMIT` | `0` | Max subs per run (0=unlimited) |
+| `YS2WL_MINIMUM_LENGTH` | `0s` | Min video duration |
+| `YS2WL_MAXIMUM_LENGTH` | `0s` | Max video duration |
+| `YS2WL_PUBLISHED_AFTER` | — | ISO8601 date filter |
+| `YS2WL_SUBSCRIPTION_IGNORE_FILE` | `.subscription-ignore` | Subscriptions to skip |
+| `YS2WL_VIDEO_IGNORE_FILE` | `.video-ignore` | Video IDs to skip |
+| `YS2WL_WORDS_IGNORE_FILE` | `.ignore-words` | Title word blocklist |
+| `YS2WL_NO_WEBBROWSER` | `false` | Skip browser auth (headless mode) |
+| `YS2WL_PIPELINE_CONCURRENCY` | `1` | Parallel pipelines |
+
+## API
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/api/health` | Health check |
+| GET/PUT | `/api/config` | Get/update runtime config |
+| GET | `/api/auth/status` | OAuth status |
+| POST | `/api/auth/device` | Start device auth flow |
+| POST | `/api/auth/poll` | Poll for auth completion |
+| GET | `/api/subscriptions` | List subscriptions |
+| GET | `/api/subscriptions/{cid}/activity` | Channel activity |
+| CRUD | `/api/rules` | Routing rules |
+| POST | `/api/pipeline/trigger` | Trigger pipeline run |
+| GET | `/api/pipeline/runs` | Pipeline run history |
+| GET | `/api/pipeline/runs/{id}` | Run details |
+| GET | `/metrics` | Prometheus metrics |
+
+## Docker
+
+```sh
+make docker
+# or
+docker build -t ys2wl .
+docker run -p 8080:8080 -v /path/to/data:/data ys2wl
+```
+
+## Development
+
+```sh
+make sync    # install dependencies
+make test    # run tests
+make lint    # ruff check
+make format  # ruff format
+make check   # lint + format check
+```
+
+Lint and format run automatically on commit via pre-commit:
+
 ```sh
 uv tool install pre-commit
 pre-commit install
 ```
 
-Lint and format run automatically on `git commit`. Run manually:
-```sh
-make check
-```
+## Kubernetes
+
+Manifests in `k8s/` — deploy with `kubectl apply -f k8s/`.

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -3,15 +3,21 @@ kind: ConfigMap
 metadata:
   name: ys2wl-config
 data:
-  YS2WL_DATABASE_FILE: /data/ys2wl.db
-  YS2WL_PICKLE_FILE: /data/credentials.pickle
-  YS2WL_CREDENTIALS_FILE: /app/credentials.json
-  YS2WL_SCHEDULE: "0 */6 * * *"
   YS2WL_API_PORT: "8080"
-  YS2WL_LOG_LEVEL: info
-  YS2WL_COMPARE_DISTANCE: "80"
-  YS2WL_REPROCESS_DAYS: "2"
-  YS2WL_PLAYLIST_SLEEP: "10"
-  YS2WL_SUBSCRIPTION_SLEEP: "30"
-  YS2WL_PIPELINE_CONCURRENCY: "1"
+  YS2WL_COMPARE_DISTANCE: "97"
+  YS2WL_CREDENTIALS_FILE: "/data/client_secret.json"
+  YS2WL_DATABASE_FILE: "/data/my.db"
+  YS2WL_LOG_FILE: "stream"
+  YS2WL_LOG_LEVEL: "debug"
+  YS2WL_MAXIMUM_LENGTH: "8m"
+  YS2WL_MINIMUM_LENGTH: "75s"
   YS2WL_NO_WEBBROWSER: "true"
+  YS2WL_PICKLE_FILE: "/data/credentials.pickle"
+  YS2WL_PIPELINE_CONCURRENCY: "1"
+  YS2WL_PLAYLIST_SLEEP: "30"
+  YS2WL_REPROCESS_DAYS: "1"
+  YS2WL_SCHEDULE: "0 */6 * * *"
+  YS2WL_SUBSCRIPTION_IGNORE_FILE: "/data/.subscription-ignore"
+  YS2WL_SUBSCRIPTION_SLEEP: "60"
+  YS2WL_VIDEO_IGNORE_FILE: "/data/.video-ignore"
+  YS2WL_WORDS_IGNORE_FILE: "/data/.words-ignore"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -21,13 +21,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: ys2wl-config
-          env:
-            - name: YS2WL_PICKLE_FILE
-              value: /data/credentials.pickle
-            - name: YS2WL_CREDENTIALS_FILE
-              value: /data/credentials.json
-            - name: YS2WL_DATABASE_FILE
-              value: /data/ys2wl.db
           volumeMounts:
             - mountPath: /data
               name: config

--- a/src/ys2wl/__main__.py
+++ b/src/ys2wl/__main__.py
@@ -1,9 +1,35 @@
+import logging
+import sys
+
 import uvicorn
 from ys2wl.config import load_settings
 
 
+def _configure_logging(level: str, log_file: str) -> None:
+    root = logging.getLogger("ys2wl")
+    if root.handlers:
+        return
+    root.setLevel(level.upper())
+
+    handler: logging.Handler
+    if log_file == "stream":
+        handler = logging.StreamHandler(sys.stdout)
+    else:
+        handler = logging.FileHandler(log_file)
+
+    handler.setLevel(level.upper())
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    )
+    root.addHandler(handler)
+
+
 def main() -> None:
     settings = load_settings()
+    _configure_logging(settings.log_level, settings.log_file)
     uvicorn.run(
         "ys2wl.api.app:create_app",
         host="0.0.0.0",

--- a/src/ys2wl/api/app.py
+++ b/src/ys2wl/api/app.py
@@ -7,6 +7,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from ys2wl.config import load_settings, Settings
+from google.auth.transport.requests import Request
 from ys2wl.core.youtube import YouTubeAPIClient
 from ys2wl.core.auth import load_credentials
 from ys2wl.core.scheduler import PipelineScheduler
@@ -17,6 +18,7 @@ from ys2wl.api.routes import (
     rules,
     pipeline as pipeline_routes,
     subscriptions,
+    stats as stats_routes,
 )
 from ys2wl.api.routes import auth as auth_routes
 from prometheus_client import make_asgi_app
@@ -44,11 +46,22 @@ async def lifespan(app: FastAPI) -> AsyncIterator:
     state.db_con.row_factory = sqlite3.Row
 
     state.credentials = load_credentials(state.settings.pickle_file)
-    if state.credentials and state.credentials.valid:
-        log.info("Loaded saved credentials")
-        state.youtube = YouTubeAPIClient(credentials=state.credentials)
+    if state.credentials:
+        if state.credentials.valid:
+            log.info("Loaded saved credentials")
+            state.youtube = YouTubeAPIClient(credentials=state.credentials)
+        elif state.credentials.expired and state.credentials.refresh_token:
+            log.info("Credentials expired — attempting refresh")
+            try:
+                state.credentials.refresh(Request())
+                log.info("Credentials refreshed successfully")
+                state.youtube = YouTubeAPIClient(credentials=state.credentials)
+            except Exception as e:
+                log.warning("Credential refresh failed: %s", e)
+        else:
+            log.info("Credentials invalid and cannot be refreshed — use UI auth flow")
     else:
-        log.info("No valid credentials found — use UI auth flow")
+        log.info("No saved credentials found — use UI auth flow")
 
     app.state.ys2wl = state
     log.info("ys2wl service started")
@@ -76,6 +89,7 @@ def create_app() -> FastAPI:
     app.include_router(rules.router, prefix="/api", tags=["rules"])
     app.include_router(pipeline_routes.router, prefix="/api", tags=["pipeline"])
     app.include_router(subscriptions.router, prefix="/api", tags=["subscriptions"])
+    app.include_router(stats_routes.router, prefix="/api", tags=["stats"])
     app.include_router(auth_routes.router, prefix="/api", tags=["auth"])
 
     metrics_app = make_asgi_app()

--- a/src/ys2wl/api/deps.py
+++ b/src/ys2wl/api/deps.py
@@ -1,0 +1,20 @@
+import logging
+from fastapi import HTTPException, Request
+
+log = logging.getLogger("ys2wl.api")
+
+
+def get_state(request: Request):
+    return request.app.state.ys2wl
+
+
+def require_youtube(state):
+    if state.youtube is None:
+        log.warning(
+            "YouTube client unavailable — credentials not loaded or not yet authenticated"
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="YouTube API not available — authenticate first",
+        )
+    return state.youtube

--- a/src/ys2wl/api/models.py
+++ b/src/ys2wl/api/models.py
@@ -97,4 +97,5 @@ class SubscriptionStat(BaseModel):
     subscription_title: str
     subscription_id: str = ""
     videos_added: int = 0
+    last_added_at: Optional[str] = None
     status: str = "inactive"

--- a/src/ys2wl/api/models.py
+++ b/src/ys2wl/api/models.py
@@ -76,6 +76,26 @@ class PipelineRunResponse(BaseModel):
     trigger: str = "scheduled"
 
 
+class RunDecisionResponse(BaseModel):
+    id: int
+    video_id: Optional[str] = None
+    title: Optional[str] = None
+    subscription_title: Optional[str] = None
+    action: str
+    reason: Optional[str] = None
+    reason_detail: Optional[str] = None
+    routed_to: Optional[str] = None
+    created_at: str
+
+
 class TriggerResponse(BaseModel):
     run_id: int
     message: str = "Pipeline triggered"
+
+
+class SubscriptionStat(BaseModel):
+    subscription_title: str
+    videos_added: int = 0
+    last_added_at: Optional[str] = None
+    total_decisions: int = 0
+    status: str = "inactive"

--- a/src/ys2wl/api/models.py
+++ b/src/ys2wl/api/models.py
@@ -95,7 +95,6 @@ class TriggerResponse(BaseModel):
 
 class SubscriptionStat(BaseModel):
     subscription_title: str
+    subscription_id: str = ""
     videos_added: int = 0
-    last_added_at: Optional[str] = None
-    total_decisions: int = 0
     status: str = "inactive"

--- a/src/ys2wl/api/routes/pipeline.py
+++ b/src/ys2wl/api/routes/pipeline.py
@@ -1,6 +1,7 @@
 from typing import List
 from fastapi import APIRouter, HTTPException, Request
-from ys2wl.api.models import TriggerResponse, PipelineRunResponse
+from ys2wl.api.deps import get_state, require_youtube
+from ys2wl.api.models import TriggerResponse, PipelineRunResponse, RunDecisionResponse
 from ys2wl.core.pipeline import PipelineOrchestrator
 from ys2wl.db import repository as repo
 from ys2wl.models.youtube import Channel, Playlist, RoutingRule
@@ -10,13 +11,10 @@ log = logging.getLogger("ys2wl.api.pipeline")
 router = APIRouter()
 
 
-def _get_state(request: Request):
-    return request.app.state.ys2wl
-
-
 @router.post("/pipeline/trigger", response_model=TriggerResponse)
 async def trigger_pipeline(request: Request):
-    state = _get_state(request)
+    state = get_state(request)
+    require_youtube(state)
     run_id = repo.create_pipeline_run(state.db_con, trigger="manual")
     if run_id is None:
         raise HTTPException(status_code=500, detail="Failed to create pipeline run")
@@ -77,6 +75,43 @@ async def trigger_pipeline(request: Request):
         )
 
         summary = orchestrator.run()
+
+        # persist per-video decisions
+        decisions = []
+        for r in summary.video_results:
+            if r.added:
+                action = "added"
+                reason = None
+                reason_detail = None
+            elif r.error:
+                action = "error"
+                reason = "add_failed"
+                reason_detail = r.error
+            elif r.filter_result:
+                action = "skipped"
+                reason = r.filter_result.skipped_by or "filter"
+                reason_detail = r.filter_result.reason
+            else:
+                action = "skipped"
+                reason = "unknown"
+                reason_detail = None
+            decisions.append(
+                {
+                    "video_id": r.video_id,
+                    "title": r.title,
+                    "subscription_title": r.subscription_title,
+                    "action": action,
+                    "reason": reason,
+                    "reason_detail": reason_detail,
+                    "routed_to": r.route_result.playlist_title
+                    if r.route_result
+                    else None,
+                }
+            )
+        if decisions:
+            repo.insert_run_decisions(state.db_con, run_id, decisions)
+        repo.cleanup_old_decisions(state.db_con)
+
         repo.finish_pipeline_run(
             state.db_con,
             run_id,
@@ -111,18 +146,28 @@ async def trigger_pipeline(request: Request):
 
 @router.get("/pipeline/runs", response_model=List[PipelineRunResponse])
 async def list_runs(request: Request):
-    state = _get_state(request)
+    state = get_state(request)
     runs = repo.get_pipeline_runs(state.db_con)
     return [PipelineRunResponse(**r) for r in runs]
 
 
 @router.get("/pipeline/runs/{run_id}", response_model=PipelineRunResponse)
 async def get_run(run_id: int, request: Request):
-    state = _get_state(request)
+    state = get_state(request)
     run = repo.get_pipeline_run(state.db_con, run_id)
     if not run:
         raise HTTPException(status_code=404, detail="Run not found")
     return PipelineRunResponse(**run)
+
+
+@router.get(
+    "/pipeline/runs/{run_id}/decisions",
+    response_model=List[RunDecisionResponse],
+)
+async def get_run_decisions(run_id: int, request: Request):
+    state = get_state(request)
+    decisions = repo.get_run_decisions(state.db_con, run_id)
+    return [RunDecisionResponse(**d) for d in decisions]
 
 
 def _load_file(filepath: str) -> list[str]:

--- a/src/ys2wl/api/routes/rules.py
+++ b/src/ys2wl/api/routes/rules.py
@@ -1,8 +1,10 @@
+import logging
 from typing import List
 from fastapi import APIRouter, HTTPException, Request
 from ys2wl.api.models import RoutingRuleCreate, RoutingRuleUpdate, RoutingRuleResponse
 from ys2wl.db import repository as repo
 
+log = logging.getLogger("ys2wl.api.rules")
 router = APIRouter()
 
 
@@ -14,12 +16,23 @@ def _get_state(request: Request):
 async def list_rules(request: Request):
     state = _get_state(request)
     rules = repo.get_routing_rules(state.db_con)
+    log.info("list_rules: found %d rules", len(rules))
+    for r in rules:
+        log.info("  rule id=%d name=%s enabled=%s", r["id"], r["name"], r["enabled"])
     return [RoutingRuleResponse(**r) for r in rules]
 
 
 @router.post("/rules", response_model=RoutingRuleResponse, status_code=201)
 async def create_rule(rule: RoutingRuleCreate, request: Request):
     state = _get_state(request)
+    log.info(
+        "Creating rule: name=%s field=%s operator=%s pattern=%s playlist=%s",
+        rule.name,
+        rule.field,
+        rule.operator,
+        rule.pattern,
+        rule.destination_playlist_id,
+    )
     rid = repo.create_routing_rule(
         state.db_con,
         rule.name,
@@ -31,7 +44,9 @@ async def create_rule(rule: RoutingRuleCreate, request: Request):
         rule.destination_playlist_title,
     )
     if rid is None:
+        log.error("Failed to create rule in database")
         raise HTTPException(status_code=500, detail="Failed to create rule")
+    log.info("Rule created with id=%d", rid)
     con = state.db_con
     cursor = con.execute("SELECT * FROM routing_rules WHERE id = ?", (rid,))
     row = cursor.fetchone()

--- a/src/ys2wl/api/routes/stats.py
+++ b/src/ys2wl/api/routes/stats.py
@@ -11,28 +11,35 @@ def _get_state(request: Request):
     return request.app.state.ys2wl
 
 
-@router.get("/api/stats/subscriptions", response_model=List[SubscriptionStat])
+@router.get("/stats/subscriptions", response_model=List[SubscriptionStat])
 async def get_subscription_stats(request: Request):
     state = _get_state(request)
     con = state.db_con
 
-    rows = con.execute(
-        """
-        SELECT subscription_title,
-               COUNT(*) FILTER (WHERE action = 'added') AS videos_added,
-               MAX(CASE WHEN action = 'added' THEN created_at END) AS last_added_at,
-               COUNT(*) AS total_decisions
-        FROM pipeline_run_decisions
-        GROUP BY subscription_title
-        ORDER BY videos_added DESC
-        """
-    ).fetchall()
+    try:
+        rows = con.execute(
+            """
+            SELECT subscription_title,
+                   COUNT(*) FILTER (WHERE action = 'added') AS videos_added,
+                   MAX(CASE WHEN action = 'added' THEN created_at END) AS last_added_at,
+                   COUNT(*) AS total_decisions
+            FROM pipeline_run_decisions
+            GROUP BY subscription_title
+            ORDER BY videos_added DESC
+            """
+        ).fetchall()
+    except Exception as e:
+        log.error("Failed to query pipeline_run_decisions: %s", e)
+        return []
 
     active_set = set()
-    for r in con.execute(
-        "SELECT DISTINCT title FROM subscription WHERE title IS NOT NULL"
-    ):
-        active_set.add(r[0])
+    try:
+        for r in con.execute(
+            "SELECT DISTINCT title FROM subscription WHERE title IS NOT NULL"
+        ):
+            active_set.add(r[0])
+    except Exception as e:
+        log.error("Failed to query subscriptions: %s", e)
 
     ignore_path = state.settings.subscription_ignore_file
     ignored_set = set()

--- a/src/ys2wl/api/routes/stats.py
+++ b/src/ys2wl/api/routes/stats.py
@@ -19,27 +19,21 @@ async def get_subscription_stats(request: Request):
     try:
         rows = con.execute(
             """
-            SELECT subscription_title,
-                   COUNT(*) FILTER (WHERE action = 'added') AS videos_added,
-                   MAX(CASE WHEN action = 'added' THEN created_at END) AS last_added_at,
-                   COUNT(*) AS total_decisions
-            FROM pipeline_run_decisions
-            GROUP BY subscription_title
+            SELECT v.subscriptionId,
+                   COALESCE(s.title, v.subscriptionId) AS title,
+                   COUNT(v.videoId) AS videos_added
+            FROM videos v
+            LEFT JOIN subscription s ON v.subscriptionId = s.id
+            GROUP BY v.subscriptionId
             ORDER BY videos_added DESC
             """
         ).fetchall()
     except Exception as e:
-        log.error("Failed to query pipeline_run_decisions: %s", e)
+        log.error("Failed to query video stats: %s", e)
         return []
 
-    active_set = set()
-    try:
-        for r in con.execute(
-            "SELECT DISTINCT title FROM subscription WHERE title IS NOT NULL"
-        ):
-            active_set.add(r[0])
-    except Exception as e:
-        log.error("Failed to query subscriptions: %s", e)
+    if not rows:
+        return []
 
     ignore_path = state.settings.subscription_ignore_file
     ignored_set = set()
@@ -54,20 +48,30 @@ async def get_subscription_stats(request: Request):
 
     result = []
     for row in rows:
-        title = row[0]
-        if title in active_set:
-            status = "active"
-        elif title in ignored_set:
+        sub_id = row[0]
+        title = row[1]
+        if title in ignored_set:
             status = "ignored"
+        elif _is_in_subscription_table(con, sub_id):
+            status = "active"
         else:
             status = "inactive"
         result.append(
             SubscriptionStat(
                 subscription_title=title,
-                videos_added=row[1] or 0,
-                last_added_at=row[2],
-                total_decisions=row[3] or 0,
+                subscription_id=sub_id,
+                videos_added=row[2] or 0,
                 status=status,
             )
         )
     return result
+
+
+def _is_in_subscription_table(con, sub_id: str) -> bool:
+    try:
+        r = con.execute(
+            "SELECT 1 FROM subscription WHERE id = ? LIMIT 1", (sub_id,)
+        ).fetchone()
+        return r is not None
+    except Exception:
+        return False

--- a/src/ys2wl/api/routes/stats.py
+++ b/src/ys2wl/api/routes/stats.py
@@ -1,0 +1,66 @@
+import logging
+from typing import List
+from fastapi import APIRouter, Request
+from ys2wl.api.models import SubscriptionStat
+
+log = logging.getLogger("ys2wl.api.stats")
+router = APIRouter()
+
+
+def _get_state(request: Request):
+    return request.app.state.ys2wl
+
+
+@router.get("/api/stats/subscriptions", response_model=List[SubscriptionStat])
+async def get_subscription_stats(request: Request):
+    state = _get_state(request)
+    con = state.db_con
+
+    rows = con.execute(
+        """
+        SELECT subscription_title,
+               COUNT(*) FILTER (WHERE action = 'added') AS videos_added,
+               MAX(CASE WHEN action = 'added' THEN created_at END) AS last_added_at,
+               COUNT(*) AS total_decisions
+        FROM pipeline_run_decisions
+        GROUP BY subscription_title
+        ORDER BY videos_added DESC
+        """
+    ).fetchall()
+
+    active_set = set()
+    for r in con.execute(
+        "SELECT DISTINCT title FROM subscription WHERE title IS NOT NULL"
+    ):
+        active_set.add(r[0])
+
+    ignore_path = state.settings.subscription_ignore_file
+    ignored_set = set()
+    try:
+        with open(ignore_path) as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    ignored_set.add(line)
+    except (FileNotFoundError, OSError):
+        pass
+
+    result = []
+    for row in rows:
+        title = row[0]
+        if title in active_set:
+            status = "active"
+        elif title in ignored_set:
+            status = "ignored"
+        else:
+            status = "inactive"
+        result.append(
+            SubscriptionStat(
+                subscription_title=title,
+                videos_added=row[1] or 0,
+                last_added_at=row[2],
+                total_decisions=row[3] or 0,
+                status=status,
+            )
+        )
+    return result

--- a/src/ys2wl/api/routes/stats.py
+++ b/src/ys2wl/api/routes/stats.py
@@ -21,7 +21,8 @@ async def get_subscription_stats(request: Request):
             """
             SELECT v.subscriptionId,
                    COALESCE(s.title, v.subscriptionId) AS title,
-                   COUNT(v.videoId) AS videos_added
+                   COUNT(v.videoId) AS videos_added,
+                   MAX(v.timestamp) AS last_added_at
             FROM videos v
             LEFT JOIN subscription s ON v.subscriptionId = s.id
             GROUP BY v.subscriptionId
@@ -61,6 +62,7 @@ async def get_subscription_stats(request: Request):
                 subscription_title=title,
                 subscription_id=sub_id,
                 videos_added=row[2] or 0,
+                last_added_at=row[3],
                 status=status,
             )
         )

--- a/src/ys2wl/api/routes/stats.py
+++ b/src/ys2wl/api/routes/stats.py
@@ -47,11 +47,19 @@ async def get_subscription_stats(request: Request):
     except (FileNotFoundError, OSError):
         pass
 
+    def _is_ignored(title: str, sub_id: str) -> bool:
+        if title in ignored_set or sub_id in ignored_set:
+            return True
+        for entry in ignored_set:
+            if entry in title or title in entry:
+                return True
+        return False
+
     result = []
     for row in rows:
         sub_id = row[0]
         title = row[1]
-        if title in ignored_set:
+        if _is_ignored(title, sub_id):
             status = "ignored"
         elif _is_in_subscription_table(con, sub_id):
             status = "active"

--- a/src/ys2wl/api/routes/subscriptions.py
+++ b/src/ys2wl/api/routes/subscriptions.py
@@ -1,7 +1,10 @@
+import logging
 from typing import List
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
+from ys2wl.api.deps import get_state, require_youtube
 
+log = logging.getLogger("ys2wl.api.subscriptions")
 router = APIRouter()
 
 
@@ -18,14 +21,15 @@ class ActivityResponse(BaseModel):
     video_type: str
 
 
-def _get_state(request: Request):
-    return request.app.state.ys2wl
-
-
 @router.get("/subscriptions", response_model=List[SubscriptionResponse])
 async def list_subscriptions(request: Request):
-    state = _get_state(request)
-    subs = state.youtube.get_subscriptions()
+    state = get_state(request)
+    youtube = require_youtube(state)
+    try:
+        subs = youtube.get_subscriptions()
+    except Exception as e:
+        log.error("Failed to list subscriptions: %s", e)
+        raise HTTPException(status_code=502, detail=str(e))
     return [
         SubscriptionResponse(id=s.id, title=s.title, channel_id=s.channel_id)
         for s in subs
@@ -36,8 +40,13 @@ async def list_subscriptions(request: Request):
     "/subscriptions/{channel_id}/activity", response_model=List[ActivityResponse]
 )
 async def get_subscription_activity(channel_id: str, request: Request):
-    state = _get_state(request)
-    activities = state.youtube.get_subscription_activity(channel_id)
+    state = get_state(request)
+    youtube = require_youtube(state)
+    try:
+        activities = youtube.get_subscription_activity(channel_id)
+    except Exception as e:
+        log.error("Failed to get activity for channel %s: %s", channel_id, e)
+        raise HTTPException(status_code=502, detail=str(e))
     return [
         ActivityResponse(
             video_id=a.video_id,

--- a/src/ys2wl/config.py
+++ b/src/ys2wl/config.py
@@ -1,6 +1,10 @@
+import logging
+
 from pydantic_settings import BaseSettings
 from pydantic import Field
 from typing import Optional
+
+log = logging.getLogger("ys2wl.config")
 
 
 class Settings(BaseSettings):
@@ -34,4 +38,6 @@ class Settings(BaseSettings):
 
 
 def load_settings() -> Settings:
-    return Settings()
+    s = Settings()
+    log.debug("config loaded: %s", s.model_dump())
+    return s

--- a/src/ys2wl/core/auth.py
+++ b/src/ys2wl/core/auth.py
@@ -92,8 +92,14 @@ def save_credentials(credentials: Credentials, path: str) -> None:
 def load_credentials(path: str) -> Optional[Credentials]:
     try:
         with open(path, "rb") as f:
-            return pickle.load(f)
-    except (FileNotFoundError, pickle.UnpicklingError, EOFError):
+            creds = pickle.load(f)
+            log.debug("Loaded credentials from %s", path)
+            return creds
+    except FileNotFoundError:
+        log.debug("No credentials file at %s", path)
+        return None
+    except (pickle.UnpicklingError, EOFError) as e:
+        log.warning("Failed to unpickle credentials from %s: %s", path, e)
         return None
 
 

--- a/src/ys2wl/db/migrations.py
+++ b/src/ys2wl/db/migrations.py
@@ -56,6 +56,18 @@ CREATE TABLE IF NOT EXISTS pipeline_runs (
     error_message TEXT,
     trigger TEXT DEFAULT 'scheduled'
 );
+CREATE TABLE IF NOT EXISTS pipeline_run_decisions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL REFERENCES pipeline_runs(id),
+    video_id TEXT,
+    title TEXT,
+    subscription_title TEXT,
+    action TEXT NOT NULL,
+    reason TEXT,
+    reason_detail TEXT,
+    routed_to TEXT,
+    created_at TEXT NOT NULL
+);
 CREATE TABLE IF NOT EXISTS app_config (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL

--- a/src/ys2wl/db/repository.py
+++ b/src/ys2wl/db/repository.py
@@ -1,6 +1,6 @@
 import sqlite3
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 log = logging.getLogger("ys2wl.db.repository")
@@ -35,6 +35,7 @@ def insert_video(
                 route_rule,
             ),
         )
+        con.commit()
         return True
     except sqlite3.Error as err:
         log.error("Failed to insert video: %s", err)
@@ -53,6 +54,7 @@ def insert_channel(con: sqlite3.Connection, channel_id: str, title: str) -> bool
             "INSERT OR REPLACE INTO channel (id, title) VALUES (?, ?)",
             (channel_id, title),
         )
+        con.commit()
         return True
     except sqlite3.Error as err:
         log.error("Failed to insert channel: %s", err)
@@ -74,6 +76,7 @@ def insert_playlist(con: sqlite3.Connection, playlist_id: str, title: str) -> bo
             "INSERT OR REPLACE INTO playlist (id, title) VALUES (?, ?)",
             (playlist_id, title),
         )
+        con.commit()
         return True
     except sqlite3.Error as err:
         log.error("Failed to insert playlist: %s", err)
@@ -97,6 +100,7 @@ def insert_subscription(
             "INSERT OR REPLACE INTO subscription (id, title, timestamp) VALUES (?, ?, ?)",
             (sub_id, title, timestamp),
         )
+        con.commit()
         return True
     except sqlite3.Error as err:
         log.error("Failed to insert subscription: %s", err)
@@ -124,6 +128,7 @@ def set_last_run(con: sqlite3.Connection, timestamp: str) -> bool:
             "INSERT OR REPLACE INTO last_run (id, timestamp) VALUES (1, ?)",
             (timestamp,),
         )
+        con.commit()
         return True
     except sqlite3.Error as err:
         log.error("Failed to set last_run: %s", err)
@@ -136,7 +141,9 @@ def get_routing_rules(con: sqlite3.Connection) -> list[dict]:
         "SELECT id, name, priority, field, operator, pattern, destination_playlist_id, destination_playlist_title, enabled "
         "FROM routing_rules WHERE enabled = 1 ORDER BY priority DESC"
     )
-    return [dict(row) for row in cursor.fetchall()]
+    results = [dict(row) for row in cursor.fetchall()]
+    log.info("get_routing_rules: %d enabled rules", len(results))
+    return results
 
 
 def create_routing_rule(
@@ -166,6 +173,7 @@ def create_routing_rule(
                 now,
             ),
         )
+        con.commit()
         return cursor.lastrowid
     except sqlite3.Error as err:
         log.error("Failed to create routing rule: %s", err)
@@ -191,6 +199,7 @@ def update_routing_rule(con: sqlite3.Connection, rule_id: int, **kwargs) -> bool
     values = list(updates.values()) + [rule_id]
     try:
         con.execute(f"UPDATE routing_rules SET {set_clause} WHERE id = ?", values)
+        con.commit()
         return True
     except sqlite3.Error as err:
         log.error("Failed to update routing rule: %s", err)
@@ -200,6 +209,7 @@ def update_routing_rule(con: sqlite3.Connection, rule_id: int, **kwargs) -> bool
 def delete_routing_rule(con: sqlite3.Connection, rule_id: int) -> bool:
     try:
         con.execute("DELETE FROM routing_rules WHERE id = ?", (rule_id,))
+        con.commit()
         return True
     except sqlite3.Error as err:
         log.error("Failed to delete routing rule: %s", err)
@@ -216,6 +226,7 @@ def create_pipeline_run(
             "INSERT INTO pipeline_runs (started_at, status, trigger) VALUES (?, 'running', ?)",
             (now, trigger),
         )
+        con.commit()
         return cursor.lastrowid
     except sqlite3.Error as err:
         log.error("Failed to create pipeline run: %s", err)
@@ -240,6 +251,7 @@ def finish_pipeline_run(con: sqlite3.Connection, run_id: int, summary: dict) -> 
                 run_id,
             ),
         )
+        con.commit()
         return True
     except sqlite3.Error as err:
         log.error("Failed to finish pipeline run: %s", err)
@@ -259,6 +271,64 @@ def get_pipeline_run(con: sqlite3.Connection, run_id: int) -> Optional[dict]:
     return dict(row) if row else None
 
 
+# -- pipeline_run_decisions --
+def insert_run_decisions(
+    con: sqlite3.Connection, run_id: int, decisions: list[dict]
+) -> bool:
+    try:
+        now = datetime.now(timezone.utc).isoformat()
+        con.executemany(
+            "INSERT INTO pipeline_run_decisions (run_id, video_id, title, subscription_title, action, reason, reason_detail, routed_to, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                (
+                    run_id,
+                    d.get("video_id"),
+                    d.get("title"),
+                    d.get("subscription_title"),
+                    d.get("action"),
+                    d.get("reason"),
+                    d.get("reason_detail"),
+                    d.get("routed_to"),
+                    now,
+                )
+                for d in decisions
+            ],
+        )
+        con.commit()
+        return True
+    except sqlite3.Error as err:
+        log.error("Failed to insert run decisions: %s", err)
+        return False
+
+
+def get_run_decisions(
+    con: sqlite3.Connection, run_id: int, limit: int = 1000
+) -> list[dict]:
+    cursor = con.execute(
+        "SELECT id, video_id, title, subscription_title, action, reason, reason_detail, routed_to, created_at "
+        "FROM pipeline_run_decisions WHERE run_id = ? ORDER BY id ASC LIMIT ?",
+        (run_id, limit),
+    )
+    return [dict(row) for row in cursor.fetchall()]
+
+
+def cleanup_old_decisions(con: sqlite3.Connection, days: int = 10) -> bool:
+    try:
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+        cursor = con.execute(
+            "DELETE FROM pipeline_run_decisions WHERE created_at < ?", (cutoff,)
+        )
+        con.commit()
+        deleted = cursor.rowcount
+        if deleted > 0:
+            log.info("Cleaned up %d old pipeline run decisions", deleted)
+        return True
+    except sqlite3.Error as err:
+        log.error("Failed to cleanup old decisions: %s", err)
+        return False
+
+
 # -- app_config --
 def get_config(con: sqlite3.Connection, key: str) -> Optional[str]:
     cursor = con.execute("SELECT value FROM app_config WHERE key = ?", (key,))
@@ -271,6 +341,7 @@ def set_config(con: sqlite3.Connection, key: str, value: str) -> bool:
         con.execute(
             "INSERT OR REPLACE INTO app_config (key, value) VALUES (?, ?)", (key, value)
         )
+        con.commit()
         return True
     except sqlite3.Error as err:
         log.error("Failed to set config '%s': %s", key, err)

--- a/src/ys2wl/filters/router.py
+++ b/src/ys2wl/filters/router.py
@@ -7,20 +7,25 @@ from ys2wl.models.pipeline import RouteResult
 def _get_field_value(
     activity: Activity, channel_title: str, duration_seconds: int, field: Optional[str]
 ) -> Optional[str]:
+    # Normalise aliases from the UI dropdown
+    alias = {"title": "video_title", "duration": "duration_seconds"}
+    resolved = alias.get(field, field)
     mapping = {
         "channel_title": channel_title,
         "video_title": activity.title,
         "video_type": activity.video_type,
     }
-    if field in mapping:
-        return mapping[field]
-    if field == "duration_seconds":
+    if resolved in mapping:
+        return mapping[resolved]
+    if resolved == "duration_seconds":
         return str(duration_seconds)
     return None
 
 
 def _matches(value: Optional[str], operator: str, pattern: Optional[str]) -> bool:
-    if value is None or pattern is None:
+    if value is None:
+        return False
+    if not pattern:
         return False
     if operator == "contains":
         return pattern.lower() in value.lower()

--- a/ui/index.html
+++ b/ui/index.html
@@ -588,10 +588,12 @@ renderers.stats = async function() {
       container.innerHTML = `<table><thead><tr>
         <th style="cursor:pointer" onclick="setStatsSort('subscription_title')">Subscription${arrow('subscription_title')}</th>
         <th style="cursor:pointer" onclick="setStatsSort('videos_added')">Videos Added${arrow('videos_added')}</th>
+        <th style="cursor:pointer" onclick="setStatsSort('last_added_at')">Last Added${arrow('last_added_at')}</th>
         <th style="cursor:pointer" onclick="setStatsSort('status')">Status${arrow('status')}</th>
       </tr></thead><tbody>${sorted.map(d => `<tr>
         <td>${escapeHtml(d.subscription_title)}</td>
         <td>${d.videos_added}</td>
+        <td style="font-size:0.75rem;color:var(--text2)">${d.last_added_at || '-'}</td>
         <td><span class="badge ${statusClass(d.status)}">${d.status}</span></td>
       </tr>`).join('')}</tbody></table>
       <p style="color:var(--text2);font-size:0.75rem">${data.length} subscription(s)</p>`;

--- a/ui/index.html
+++ b/ui/index.html
@@ -143,12 +143,13 @@ label { display: block; font-size: 0.875rem; color: var(--text2); margin-bottom:
 
 <nav class="sidebar" id="sidebar">
   <h1>ys2wl</h1>
-  <a class="active" data-page="dashboard">Dashboard</a>
-  <a data-page="subscriptions">Subscriptions</a>
-  <a data-page="rules">Routing Rules</a>
-  <a data-page="config">Config</a>
-  <a data-page="runs">Pipeline Runs</a>
-  <a data-page="auth">Auth</a>
+  <a class="active" data-page="dashboard" href="#dashboard">Dashboard</a>
+  <a data-page="subscriptions" href="#subscriptions">Subscriptions</a>
+  <a data-page="rules" href="#rules">Routing Rules</a>
+  <a data-page="config" href="#config">Config</a>
+  <a data-page="runs" href="#runs">Pipeline Runs</a>
+  <a data-page="stats" href="#stats">Stats</a>
+  <a data-page="auth" href="#auth">Auth</a>
 </nav>
 
 <div class="main">
@@ -187,12 +188,12 @@ label { display: block; font-size: 0.875rem; color: var(--text2); margin-bottom:
         <div class="form-group"><label>Name</label><input id="ruleName"></div>
         <div class="form-group"><label>Priority</label><input id="rulePriority" type="number" value="0"></div>
         <div class="form-group"><label>Field</label>
-          <select id="ruleField"><option value="">Any</option><option value="title">Title</option>
-          <option value="channel_title">Channel Title</option><option value="duration">Duration</option></select></div>
+          <select id="ruleField"><option value="">Any</option><option value="video_title">Title</option>
+          <option value="channel_title">Channel Title</option><option value="duration_seconds">Duration</option></select></div>
         <div class="form-group"><label>Operator</label>
           <select id="ruleOperator"><option>contains</option><option>regex</option><option>eq</option>
           <option>lt</option><option>gt</option></select></div>
-        <div class="form-group"><label>Pattern</label><input id="rulePattern"></div>
+        <div class="form-group"><label>Pattern</label><input id="rulePattern" placeholder="leave empty to match all (contains/regex only)"></div>
         <div class="form-group"><label>Destination Playlist ID</label><input id="ruleDestId"></div>
         <div class="form-group"><label>Destination Playlist Title</label><input id="ruleDestTitle"></div>
         <div style="display:flex;gap:0.5rem;justify-content:flex-end">
@@ -210,6 +211,16 @@ label { display: block; font-size: 0.875rem; color: var(--text2); margin-bottom:
   <section id="runs" class="page">
     <h2>Pipeline Runs</h2>
     <div id="runsList"></div>
+  </section>
+  <section id="run-detail" class="page">
+    <h2>Run Details</h2>
+    <div id="runDetailSummary"></div>
+    <p><a href="#runs" style="color:var(--accent);cursor:pointer">&larr; Back to Runs</a></p>
+    <div id="runDetailDecisions"><p style="color:var(--text2)">Loading...</p></div>
+  </section>
+  <section id="stats" class="page">
+    <h2>Stats</h2>
+    <div id="statsTable"></div>
   </section>
   <section id="auth" class="page">
     <h2>Authentication</h2>
@@ -247,7 +258,7 @@ function escapeHtml(s) {
 }
 
 // ---- Routing ----
-const PAGES = ['dashboard','subscriptions','rules','config','runs','auth'];
+const PAGES = ['dashboard','subscriptions','rules','config','runs','stats','auth'];
 
 function navigate(page) {
   location.hash = '#' + page;
@@ -264,9 +275,18 @@ function renderPage(page) {
 }
 
 window.addEventListener('hashchange', () => {
-  const page = location.hash.slice(1) || 'dashboard';
-  if (PAGES.includes(page)) renderPage(page);
-  else navigate('dashboard');
+  const hash = location.hash.slice(1) || 'dashboard';
+  const runMatch = hash.match(/^run-detail-(\d+)$/);
+  if (runMatch) {
+    document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));
+    document.querySelectorAll('.sidebar a').forEach(a => a.classList.remove('active'));
+    document.getElementById('run-detail').classList.add('active');
+    renderers.runDetail(parseInt(runMatch[1]));
+  } else if (PAGES.includes(hash)) {
+    renderPage(hash);
+  } else {
+    navigate('dashboard');
+  }
 });
 
 // ---- Health check ----
@@ -282,6 +302,7 @@ async function updateHealth() {
 }
 
 // ---- Dashboard renderer ----
+const renderers = {};
 renderers.dashboard = async function() {
   try {
     const [subs, rules, runs] = await Promise.all([
@@ -428,7 +449,7 @@ document.getElementById('ruleSave')?.addEventListener('click', async function() 
     priority: parseInt(document.getElementById('rulePriority').value) || 0,
     field: document.getElementById('ruleField').value || null,
     operator: document.getElementById('ruleOperator').value,
-    pattern: document.getElementById('rulePattern').value || null,
+    pattern: document.getElementById('rulePattern').value,
     destination_playlist_id: document.getElementById('ruleDestId').value,
     destination_playlist_title: document.getElementById('ruleDestTitle').value,
   };
@@ -488,7 +509,7 @@ renderers.runs = async function() {
     }
     container.innerHTML = `<table><thead><tr>
       <th>ID</th><th>Started</th><th>Status</th><th>Trigger</th><th>Processed</th><th>Skipped</th><th>Errors</th>
-    </tr></thead><tbody>${runs.map(r => `<tr>
+    </tr></thead><tbody>${runs.map(r => `<tr style="cursor:pointer" onclick="location.hash='#run-detail-${r.id}'">
       <td>${r.id}</td>
       <td style="font-size:0.75rem;color:var(--text2)">${r.started_at || '-'}</td>
       <td><span class="badge ${r.status === 'success' ? 'badge-ok' : r.status === 'failed' ? 'badge-fail' : 'badge-run'}">${r.status || '-'}</span></td>
@@ -498,6 +519,89 @@ renderers.runs = async function() {
       <td>${r.errors ?? '-'}</td>
     </tr>`).join('')}</tbody></table>`;
   } catch { container.innerHTML = '<p style="color:var(--error)">Failed to load runs</p>'; }
+};
+
+renderers.runDetail = async function(runId) {
+  const summaryEl = document.getElementById('runDetailSummary');
+  const decisionsEl = document.getElementById('runDetailDecisions');
+  decisionsEl.innerHTML = '<p style="color:var(--text2)">Loading...</p>';
+  try {
+    const [run, decisions] = await Promise.all([
+      api('/api/pipeline/runs/' + runId),
+      api('/api/pipeline/runs/' + runId + '/decisions'),
+    ]);
+    summaryEl.innerHTML = `<div class="card" style="margin-bottom:1rem">
+      <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:0.5rem">
+        <div><strong>Run #${run.id}</strong></div>
+        <div>Status: <span class="badge ${run.status === 'success' ? 'badge-ok' : run.status === 'failed' ? 'badge-fail' : 'badge-run'}">${run.status}</span></div>
+        <div>Started: <span style="color:var(--text2);font-size:0.75rem">${run.started_at || '-'}</span></div>
+        <div>Finished: <span style="color:var(--text2);font-size:0.75rem">${run.finished_at || '-'}</span></div>
+        <div>Subscriptions: ${run.subscriptions_processed ?? '-'}</div>
+        <div>Added: ${run.videos_added ?? '-'}</div>
+        <div>Skipped: ${run.videos_skipped ?? '-'}</div>
+        <div>Errors: ${run.errors ?? '-'}</div>
+      </div>
+    </div>`;
+    if (!Array.isArray(decisions) || decisions.length === 0) {
+      decisionsEl.innerHTML = '<p style="color:var(--text2)">No decisions logged for this run</p>'; return;
+    }
+    decisionsEl.innerHTML = `<table><thead><tr>
+      <th>Video</th><th>Channel</th><th>Action</th><th>Reason</th><th>Routed To</th>
+    </tr></thead><tbody>${decisions.map(d => `<tr>
+      <td style="max-width:250px;overflow:hidden;text-overflow:ellipsis">${escapeHtml(d.title)}</td>
+      <td>${escapeHtml(d.subscription_title)}</td>
+      <td><span class="badge ${d.action === 'added' ? 'badge-ok' : d.action === 'error' ? 'badge-fail' : 'badge-run'}">${d.action}</span></td>
+      <td style="max-width:300px;overflow:hidden;text-overflow:ellipsis">${escapeHtml(d.reason_detail || d.reason || '-')}</td>
+      <td>${escapeHtml(d.routed_to || '-')}</td>
+    </tr>`).join('')}</tbody></table>
+    <p style="color:var(--text2);font-size:0.75rem">${decisions.length} decision(s)</p>`;
+  } catch { decisionsEl.innerHTML = '<p style="color:var(--error)">Failed to load run details</p>'; }
+};
+
+renderers.stats = async function() {
+  const container = document.getElementById('statsTable');
+  container.innerHTML = '<p style="color:var(--text2)">Loading...</p>';
+  try {
+    const data = await api('/api/stats/subscriptions');
+    if (!Array.isArray(data) || data.length === 0) {
+      container.innerHTML = '<p style="color:var(--text2)">No stats yet — run the pipeline first</p>'; return;
+    }
+    let sortCol = 'videos_added';
+    let sortDir = 'desc';
+    window.setStatsSort = function(col) {
+      if (sortCol === col) sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+      else { sortCol = col; sortDir = col === 'subscription_title' ? 'asc' : 'desc'; }
+      renderTable();
+    };
+    function renderTable() {
+      const sorted = [...data].sort((a, b) => {
+        let va = a[sortCol], vb = b[sortCol];
+        if (typeof va === 'string') { va = va.toLowerCase(); vb = (vb || '').toLowerCase(); }
+        if (va == null) va = '';
+        if (vb == null) vb = '';
+        if (va < vb) return sortDir === 'asc' ? -1 : 1;
+        if (va > vb) return sortDir === 'asc' ? 1 : -1;
+        return 0;
+      });
+      const arrow = (col) => sortCol === col ? (sortDir === 'asc' ? ' \u2191' : ' \u2193') : '';
+      const statusClass = (s) => s === 'active' ? 'badge-ok' : s === 'ignored' ? 'badge-run' : '';
+      container.innerHTML = `<table><thead><tr>
+        <th style="cursor:pointer" onclick="setStatsSort('subscription_title')">Subscription${arrow('subscription_title')}</th>
+        <th style="cursor:pointer" onclick="setStatsSort('videos_added')">Videos Added${arrow('videos_added')}</th>
+        <th style="cursor:pointer" onclick="setStatsSort('last_added_at')">Last Added${arrow('last_added_at')}</th>
+        <th style="cursor:pointer" onclick="setStatsSort('status')">Status${arrow('status')}</th>
+        <th style="cursor:pointer" onclick="setStatsSort('total_decisions')">Total${arrow('total_decisions')}</th>
+      </tr></thead><tbody>${sorted.map(d => `<tr>
+        <td>${escapeHtml(d.subscription_title)}</td>
+        <td>${d.videos_added}</td>
+        <td style="font-size:0.75rem;color:var(--text2)">${d.last_added_at || '-'}</td>
+        <td><span class="badge ${statusClass(d.status)}">${d.status}</span></td>
+        <td>${d.total_decisions}</td>
+      </tr>`).join('')}</tbody></table>
+      <p style="color:var(--text2);font-size:0.75rem">${data.length} subscription(s)</p>`;
+    }
+    renderTable();
+  } catch { container.innerHTML = '<p style="color:var(--error)">Failed to load stats</p>'; }
 };
 
 // ---- Auth renderer ----
@@ -566,7 +670,6 @@ async function pollAuthStatus() {
 }
 
 // ---- Init ----
-const renderers = {};
 if (!location.hash) navigate('dashboard');
 renderPage(location.hash.slice(1) || 'dashboard');
 updateHealth();

--- a/ui/index.html
+++ b/ui/index.html
@@ -588,20 +588,16 @@ renderers.stats = async function() {
       container.innerHTML = `<table><thead><tr>
         <th style="cursor:pointer" onclick="setStatsSort('subscription_title')">Subscription${arrow('subscription_title')}</th>
         <th style="cursor:pointer" onclick="setStatsSort('videos_added')">Videos Added${arrow('videos_added')}</th>
-        <th style="cursor:pointer" onclick="setStatsSort('last_added_at')">Last Added${arrow('last_added_at')}</th>
         <th style="cursor:pointer" onclick="setStatsSort('status')">Status${arrow('status')}</th>
-        <th style="cursor:pointer" onclick="setStatsSort('total_decisions')">Total${arrow('total_decisions')}</th>
       </tr></thead><tbody>${sorted.map(d => `<tr>
         <td>${escapeHtml(d.subscription_title)}</td>
         <td>${d.videos_added}</td>
-        <td style="font-size:0.75rem;color:var(--text2)">${d.last_added_at || '-'}</td>
         <td><span class="badge ${statusClass(d.status)}">${d.status}</span></td>
-        <td>${d.total_decisions}</td>
       </tr>`).join('')}</tbody></table>
       <p style="color:var(--text2);font-size:0.75rem">${data.length} subscription(s)</p>`;
     }
     renderTable();
-  } catch { container.innerHTML = '<p style="color:var(--error)">Failed to load stats</p>'; }
+  } catch (e) { container.innerHTML = '<p style="color:var(--error)">Failed to load stats: ' + e.message + '</p>'; }
 };
 
 // ---- Auth renderer ----

--- a/ui/index.html
+++ b/ui/index.html
@@ -564,7 +564,7 @@ renderers.stats = async function() {
   try {
     const data = await api('/api/stats/subscriptions');
     if (!Array.isArray(data) || data.length === 0) {
-      container.innerHTML = '<p style="color:var(--text2)">No stats yet — run the pipeline first</p>'; return;
+      container.innerHTML = '<p style="color:var(--text2)">No data yet</p>'; return;
     }
     let sortCol = 'videos_added';
     let sortDir = 'desc';


### PR DESCRIPTION
## Changes

### New
- `api/deps.py` — shared `get_state` + `require_youtube` (DRY across pipeline + subscriptions routes)
- `pipeline_run_decisions` table — per-video decision audit trail with FK to pipeline_runs
- API endpoint `GET /pipeline/runs/{id}/decisions`
- Logging: per-module loggers with debug/info/warn messages throughout

### Fixes
- Docker HEALTHCHECK restored (lost in earlier edit)
- k8s configmap: `credential.pickle` → `credentials.pickle` (typo)
- \__main__.py: guard against duplicate log handlers on re-initialization
- router `_matches`: empty/null pattern now returns `False` (was matching everything for contains/regex)
- `get_routing_rules`: removed redundant COUNT queries
- `insert_run_decisions`: type hint `list` → `list[dict]`

### Database
- All write functions now explicitly `con.commit()` (previously relied on auto-commit / external tx)
- FK constraint on `pipeline_run_decisions.run_id → pipeline_runs(id)`

### Dependencies
- `timedelta` import added to repository.py