### PR TITLE
feat: db-backed config with UI editing

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -17,7 +17,4 @@ data:
   YS2WL_PLAYLIST_SLEEP: "30"
   YS2WL_REPROCESS_DAYS: "1"
   YS2WL_SCHEDULE: "0 */6 * * *"
-  YS2WL_SUBSCRIPTION_IGNORE_FILE: "/data/.subscription-ignore"
   YS2WL_SUBSCRIPTION_SLEEP: "60"
-  YS2WL_VIDEO_IGNORE_FILE: "/data/.video-ignore"
-  YS2WL_WORDS_IGNORE_FILE: "/data/.words-ignore"

--- a/src/ys2wl/api/app.py
+++ b/src/ys2wl/api/app.py
@@ -12,6 +12,7 @@ from ys2wl.core.youtube import YouTubeAPIClient
 from ys2wl.core.auth import load_credentials
 from ys2wl.core.scheduler import PipelineScheduler
 from ys2wl.db.migrations import init_db
+from ys2wl.db import repository as repo
 from ys2wl.api.routes import (
     health,
     config,
@@ -62,6 +63,40 @@ async def lifespan(app: FastAPI) -> AsyncIterator:
             log.info("Credentials invalid and cannot be refreshed — use UI auth flow")
     else:
         log.info("No saved credentials found — use UI auth flow")
+
+    # Overlay DB config onto settings (DB wins)
+    for key in [
+        "schedule",
+        "compare_distance",
+        "reprocess_days",
+        "playlist_sleep",
+        "subscription_sleep",
+        "pipeline_concurrency",
+        "activity_limit",
+        "subscription_limit",
+        "log_level",
+        "minimum_length",
+        "maximum_length",
+        "published_after",
+        "no_webbrowser",
+        "client_secret_json",
+    ]:
+        db_val = repo.get_config(state.db_con, key)
+        if db_val is not None and hasattr(state.settings, key):
+            try:
+                val = getattr(state.settings, key)
+                if isinstance(val, bool):
+                    setattr(state.settings, key, db_val.lower() in ("true", "1", "yes"))
+                elif isinstance(val, int):
+                    setattr(state.settings, key, int(db_val))
+                else:
+                    setattr(state.settings, key, db_val)
+            except (ValueError, TypeError):
+                log.warning("Failed to parse config %s = %s", key, db_val)
+        elif db_val is None:
+            env_val = getattr(state.settings, key)
+            if env_val is not None:
+                repo.set_config(state.db_con, key, str(env_val))
 
     app.state.ys2wl = state
     log.info("ys2wl service started")

--- a/src/ys2wl/api/app.py
+++ b/src/ys2wl/api/app.py
@@ -45,7 +45,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator:
     state.db_con = sqlite3.connect(state.settings.database_file)
     state.db_con.row_factory = sqlite3.Row
 
-    state.credentials = load_credentials(state.settings.pickle_file)
+    state.credentials = load_credentials(state.db_con)
     if state.credentials:
         if state.credentials.valid:
             log.info("Loaded saved credentials")

--- a/src/ys2wl/api/models.py
+++ b/src/ys2wl/api/models.py
@@ -16,6 +16,11 @@ class ConfigResponse(BaseModel):
     activity_limit: int
     subscription_limit: int
     log_level: str
+    minimum_length: str
+    maximum_length: str
+    published_after: Optional[str] = None
+    no_webbrowser: bool
+    client_secret_json: str = ""
 
 
 class ConfigUpdate(BaseModel):
@@ -28,6 +33,27 @@ class ConfigUpdate(BaseModel):
     activity_limit: Optional[int] = Field(None, ge=0)
     subscription_limit: Optional[int] = Field(None, ge=0)
     log_level: Optional[str] = None
+    minimum_length: Optional[str] = None
+    maximum_length: Optional[str] = None
+    published_after: Optional[str] = None
+    no_webbrowser: Optional[bool] = None
+    client_secret_json: Optional[str] = None
+
+
+class IgnoreEntryCreate(BaseModel):
+    type: str  # subscription, video, words
+    pattern: str
+
+
+class IgnoreEntryUpdate(BaseModel):
+    pattern: str
+
+
+class IgnoreEntryResponse(BaseModel):
+    id: int
+    type: str
+    pattern: str
+    created_at: str
 
 
 class RoutingRuleCreate(BaseModel):

--- a/src/ys2wl/api/routes/auth.py
+++ b/src/ys2wl/api/routes/auth.py
@@ -42,7 +42,7 @@ async def auth_status(request: Request):
 @router.post("/auth/device", response_model=DeviceFlowResponse)
 async def auth_device(request: Request):
     state = _get_state(request)
-    config = get_client_config(state.settings.credentials_file)
+    config = get_client_config(state.db_con)
     if not config or not config.get("client_id"):
         raise HTTPException(
             status_code=400, detail="credentials.json not found or invalid"
@@ -74,7 +74,7 @@ async def auth_poll(request: Request):
         state.device_flow["device_code"],
     )
     if creds:
-        save_credentials(creds, state.settings.pickle_file)
+        save_credentials(state.db_con, creds)
         state.credentials = creds
         state.youtube = YouTubeAPIClient(credentials=creds)
         state.device_flow = None

--- a/src/ys2wl/api/routes/config.py
+++ b/src/ys2wl/api/routes/config.py
@@ -1,5 +1,12 @@
-from fastapi import APIRouter, Request
-from ys2wl.api.models import ConfigResponse, ConfigUpdate
+from typing import List
+from fastapi import APIRouter, HTTPException, Request
+from ys2wl.api.models import (
+    ConfigResponse,
+    ConfigUpdate,
+    IgnoreEntryCreate,
+    IgnoreEntryUpdate,
+    IgnoreEntryResponse,
+)
 from ys2wl.db import repository as repo
 
 router = APIRouter()
@@ -9,20 +16,39 @@ def _get_state(request: Request):
     return request.app.state.ys2wl
 
 
+def _get_db_val(state, key: str, fallback):
+    db_val = repo.get_config(state.db_con, key)
+    return db_val if db_val is not None else fallback
+
+
 @router.get("/config", response_model=ConfigResponse)
 async def get_config(request: Request):
     state = _get_state(request)
     s = state.settings
     return ConfigResponse(
-        schedule=s.schedule,
-        compare_distance=s.compare_distance,
-        reprocess_days=s.reprocess_days,
-        playlist_sleep=s.playlist_sleep,
-        subscription_sleep=s.subscription_sleep,
-        pipeline_concurrency=s.pipeline_concurrency,
-        activity_limit=s.activity_limit,
-        subscription_limit=s.subscription_limit,
-        log_level=s.log_level,
+        schedule=_get_db_val(state, "schedule", s.schedule),
+        compare_distance=int(
+            _get_db_val(state, "compare_distance", s.compare_distance)
+        ),
+        reprocess_days=int(_get_db_val(state, "reprocess_days", s.reprocess_days)),
+        playlist_sleep=int(_get_db_val(state, "playlist_sleep", s.playlist_sleep)),
+        subscription_sleep=int(
+            _get_db_val(state, "subscription_sleep", s.subscription_sleep)
+        ),
+        pipeline_concurrency=int(
+            _get_db_val(state, "pipeline_concurrency", s.pipeline_concurrency)
+        ),
+        activity_limit=int(_get_db_val(state, "activity_limit", s.activity_limit)),
+        subscription_limit=int(
+            _get_db_val(state, "subscription_limit", s.subscription_limit)
+        ),
+        log_level=_get_db_val(state, "log_level", s.log_level),
+        minimum_length=_get_db_val(state, "minimum_length", s.minimum_length),
+        maximum_length=_get_db_val(state, "maximum_length", s.maximum_length),
+        published_after=_get_db_val(state, "published_after", s.published_after),
+        no_webbrowser=_get_db_val(state, "no_webbrowser", str(s.no_webbrowser))
+        == "True",
+        client_secret_json=_get_db_val(state, "client_secret_json", ""),
     )
 
 
@@ -35,3 +61,43 @@ async def update_config(update: ConfigUpdate, request: Request):
             setattr(s, k, v)
             repo.set_config(state.db_con, k, str(v))
     return await get_config(request)
+
+
+@router.get("/config/ignores", response_model=List[IgnoreEntryResponse])
+async def list_ignores(type: str, request: Request):
+    state = _get_state(request)
+    if type not in ("subscription", "video", "words"):
+        raise HTTPException(status_code=400, detail="Invalid type")
+    return repo.get_ignore_entries(state.db_con, type)
+
+
+@router.post("/config/ignores", response_model=IgnoreEntryResponse, status_code=201)
+async def create_ignore(entry: IgnoreEntryCreate, request: Request):
+    state = _get_state(request)
+    if entry.type not in ("subscription", "video", "words"):
+        raise HTTPException(status_code=400, detail="Invalid type")
+    entry_id = repo.add_ignore_entry(state.db_con, entry.type, entry.pattern)
+    if entry_id is None:
+        raise HTTPException(status_code=500, detail="Failed to create entry")
+    entries = repo.get_ignore_entries(state.db_con, entry.type)
+    return next(e for e in entries if e["id"] == entry_id)
+
+
+@router.put("/config/ignores/{entry_id:int}", response_model=IgnoreEntryResponse)
+async def update_ignore(entry_id: int, update: IgnoreEntryUpdate, request: Request):
+    state = _get_state(request)
+    if not repo.update_ignore_entry(state.db_con, entry_id, update.pattern):
+        raise HTTPException(status_code=404, detail="Entry not found")
+    for t in ("subscription", "video", "words"):
+        entries = repo.get_ignore_entries(state.db_con, t)
+        for e in entries:
+            if e["id"] == entry_id:
+                return e
+    raise HTTPException(status_code=404, detail="Entry not found")
+
+
+@router.delete("/config/ignores/{entry_id:int}", status_code=204)
+async def delete_ignore(entry_id: int, request: Request):
+    state = _get_state(request)
+    if not repo.delete_ignore_entry(state.db_con, entry_id):
+        raise HTTPException(status_code=404, detail="Entry not found")

--- a/src/ys2wl/api/routes/pipeline.py
+++ b/src/ys2wl/api/routes/pipeline.py
@@ -40,9 +40,15 @@ async def trigger_pipeline(request: Request):
         channel = Channel(id=channel_data["id"], title=channel_data["title"])
         playlist = Playlist(id=playlist_data["id"], title=playlist_data["title"])
 
-        ignore_subs = _load_file(state.settings.subscription_ignore_file)
-        ignore_vids = _load_file(state.settings.video_ignore_file)
-        ignore_words = _load_file(state.settings.words_ignore_file)
+        ignore_subs = [
+            e["pattern"] for e in repo.get_ignore_entries(state.db_con, "subscription")
+        ]
+        ignore_vids = [
+            e["pattern"] for e in repo.get_ignore_entries(state.db_con, "video")
+        ]
+        ignore_words = [
+            e["pattern"] for e in repo.get_ignore_entries(state.db_con, "words")
+        ]
 
         db_rules = repo.get_routing_rules(state.db_con)
         routing_rules = [
@@ -168,11 +174,3 @@ async def get_run_decisions(run_id: int, request: Request):
     state = get_state(request)
     decisions = repo.get_run_decisions(state.db_con, run_id)
     return [RunDecisionResponse(**d) for d in decisions]
-
-
-def _load_file(filepath: str) -> list[str]:
-    try:
-        with open(filepath) as f:
-            return [line.strip() for line in f if line.strip()]
-    except (FileNotFoundError, OSError):
-        return []

--- a/src/ys2wl/api/routes/stats.py
+++ b/src/ys2wl/api/routes/stats.py
@@ -2,6 +2,7 @@ import logging
 from typing import List
 from fastapi import APIRouter, Request
 from ys2wl.api.models import SubscriptionStat
+from ys2wl.db import repository as repo
 
 log = logging.getLogger("ys2wl.api.stats")
 router = APIRouter()
@@ -36,16 +37,9 @@ async def get_subscription_stats(request: Request):
     if not rows:
         return []
 
-    ignore_path = state.settings.subscription_ignore_file
     ignored_set = set()
-    try:
-        with open(ignore_path) as f:
-            for line in f:
-                line = line.strip()
-                if line and not line.startswith("#"):
-                    ignored_set.add(line)
-    except (FileNotFoundError, OSError):
-        pass
+    for entry in repo.get_ignore_entries(state.db_con, "subscription"):
+        ignored_set.add(entry["pattern"])
 
     def _is_ignored(title: str, sub_id: str) -> bool:
         if title in ignored_set or sub_id in ignored_set:

--- a/src/ys2wl/config.py
+++ b/src/ys2wl/config.py
@@ -31,9 +31,6 @@ class Settings(BaseSettings):
     minimum_length: str = Field(default="0s")
     maximum_length: str = Field(default="0s")
     published_after: Optional[str] = Field(default=None)
-    subscription_ignore_file: str = Field(default=".subscription-ignore")
-    video_ignore_file: str = Field(default=".video-ignore")
-    words_ignore_file: str = Field(default=".ignore-words")
     no_webbrowser: bool = Field(default=False)
 
 

--- a/src/ys2wl/core/auth.py
+++ b/src/ys2wl/core/auth.py
@@ -1,12 +1,14 @@
+import base64
 import json
 import logging
-import os
 import pickle
+import sqlite3
 from typing import Optional
 from google.auth.credentials import Credentials
 from google.oauth2.credentials import Credentials as OAuth2Credentials
 from google.auth.transport.requests import Request
 import httpx
+from ys2wl.db import repository as repo
 
 log = logging.getLogger("ys2wl.auth")
 
@@ -21,18 +23,21 @@ DEVICE_CODE_URL = "https://oauth2.googleapis.com/device/code"
 TOKEN_URL = "https://oauth2.googleapis.com/token"
 
 
-def get_client_config(credentials_file: str) -> Optional[dict]:
-    """Extract client_id and client_secret from Google OAuth credentials JSON."""
+def get_client_config(db_con: sqlite3.Connection) -> Optional[dict]:
+    """Extract client_id and client_secret from Google OAuth credentials JSON in DB."""
     try:
-        with open(credentials_file) as f:
-            data = json.load(f)
+        raw = repo.get_config(db_con, "client_secret_json")
+        if not raw:
+            log.error("No client_secret_json in app_config")
+            return None
+        data = json.loads(raw)
         installed = data.get("installed") or data.get("web", {})
         return {
             "client_id": installed.get("client_id"),
             "client_secret": installed.get("client_secret"),
         }
-    except (FileNotFoundError, KeyError, json.JSONDecodeError) as e:
-        log.error("Failed to read credentials file: %s", e)
+    except (KeyError, json.JSONDecodeError) as e:
+        log.error("Failed to read credentials from DB: %s", e)
         return None
 
 
@@ -83,23 +88,22 @@ def poll_device_flow(
     return None, error
 
 
-def save_credentials(credentials: Credentials, path: str) -> None:
-    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-    with open(path, "wb") as f:
-        pickle.dump(credentials, f)
+def save_credentials(db_con: sqlite3.Connection, credentials: Credentials) -> None:
+    blob = base64.b64encode(pickle.dumps(credentials)).decode("ascii")
+    repo.set_config(db_con, "credentials_pickle", blob)
 
 
-def load_credentials(path: str) -> Optional[Credentials]:
+def load_credentials(db_con: sqlite3.Connection) -> Optional[Credentials]:
     try:
-        with open(path, "rb") as f:
-            creds = pickle.load(f)
-            log.debug("Loaded credentials from %s", path)
-            return creds
-    except FileNotFoundError:
-        log.debug("No credentials file at %s", path)
-        return None
-    except (pickle.UnpicklingError, EOFError) as e:
-        log.warning("Failed to unpickle credentials from %s: %s", path, e)
+        raw = repo.get_config(db_con, "credentials_pickle")
+        if not raw:
+            log.debug("No credentials_pickle in app_config")
+            return None
+        creds = pickle.loads(base64.b64decode(raw))
+        log.debug("Loaded credentials from DB")
+        return creds
+    except (pickle.UnpicklingError, EOFError, ValueError) as e:
+        log.warning("Failed to unpickle credentials from DB: %s", e)
         return None
 
 

--- a/src/ys2wl/db/migrations.py
+++ b/src/ys2wl/db/migrations.py
@@ -72,6 +72,13 @@ CREATE TABLE IF NOT EXISTS app_config (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
+CREATE TABLE IF NOT EXISTS ignore_entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    type TEXT NOT NULL CHECK(type IN ('subscription', 'video', 'words')),
+    pattern TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_ignore_type ON ignore_entries(type);
 """
 
 

--- a/src/ys2wl/db/repository.py
+++ b/src/ys2wl/db/repository.py
@@ -346,3 +346,51 @@ def set_config(con: sqlite3.Connection, key: str, value: str) -> bool:
     except sqlite3.Error as err:
         log.error("Failed to set config '%s': %s", key, err)
         return False
+
+
+# -- ignore_entries --
+def get_ignore_entries(con: sqlite3.Connection, ignore_type: str) -> list[dict]:
+    cursor = con.execute(
+        "SELECT id, type, pattern, created_at FROM ignore_entries WHERE type = ? ORDER BY id",
+        (ignore_type,),
+    )
+    return [dict(row) for row in cursor.fetchall()]
+
+
+def add_ignore_entry(
+    con: sqlite3.Connection, ignore_type: str, pattern: str
+) -> Optional[int]:
+    now = datetime.now(timezone.utc).isoformat()
+    try:
+        cursor = con.execute(
+            "INSERT INTO ignore_entries (type, pattern, created_at) VALUES (?, ?, ?)",
+            (ignore_type, pattern, now),
+        )
+        con.commit()
+        return cursor.lastrowid
+    except sqlite3.Error as err:
+        log.error("Failed to add ignore entry: %s", err)
+        return None
+
+
+def update_ignore_entry(con: sqlite3.Connection, entry_id: int, pattern: str) -> bool:
+    try:
+        con.execute(
+            "UPDATE ignore_entries SET pattern = ? WHERE id = ?",
+            (pattern, entry_id),
+        )
+        con.commit()
+        return True
+    except sqlite3.Error as err:
+        log.error("Failed to update ignore entry: %s", err)
+        return False
+
+
+def delete_ignore_entry(con: sqlite3.Connection, entry_id: int) -> bool:
+    try:
+        con.execute("DELETE FROM ignore_entries WHERE id = ?", (entry_id,))
+        con.commit()
+        return True
+    except sqlite3.Error as err:
+        log.error("Failed to delete ignore entry: %s", err)
+        return False

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,37 +1,47 @@
 import json
-import tempfile
-import os
+import sqlite3
+from ys2wl.db import repository as repo
 from ys2wl.core.auth import (
     get_client_config,
     credentials_status,
 )
 
 
-def test_get_client_config_returns_none_for_missing_file():
-    result = get_client_config("/nonexistent/credentials.json")
+def _db() -> sqlite3.Connection:
+    con = sqlite3.connect(":memory:")
+    con.row_factory = sqlite3.Row
+    con.execute(
+        "CREATE TABLE IF NOT EXISTS app_config (key TEXT PRIMARY KEY, value TEXT)"
+    )
+    return con
+
+
+def test_get_client_config_returns_none_for_missing():
+    db_con = _db()
+    result = get_client_config(db_con)
     assert result is None
 
 
 def test_get_client_config_parses_installed():
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-        json.dump({"installed": {"client_id": "abc", "client_secret": "def"}}, f)
-        path = f.name
-    try:
-        result = get_client_config(path)
-        assert result == {"client_id": "abc", "client_secret": "def"}
-    finally:
-        os.unlink(path)
+    db_con = _db()
+    repo.set_config(
+        db_con,
+        "client_secret_json",
+        json.dumps({"installed": {"client_id": "abc", "client_secret": "def"}}),
+    )
+    result = get_client_config(db_con)
+    assert result == {"client_id": "abc", "client_secret": "def"}
 
 
 def test_get_client_config_parses_web():
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-        json.dump({"web": {"client_id": "xyz", "client_secret": "123"}}, f)
-        path = f.name
-    try:
-        result = get_client_config(path)
-        assert result == {"client_id": "xyz", "client_secret": "123"}
-    finally:
-        os.unlink(path)
+    db_con = _db()
+    repo.set_config(
+        db_con,
+        "client_secret_json",
+        json.dumps({"web": {"client_id": "xyz", "client_secret": "123"}}),
+    )
+    result = get_client_config(db_con)
+    assert result == {"client_id": "xyz", "client_secret": "123"}
 
 
 def test_credentials_status_none():

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -1,5 +1,16 @@
+import sqlite3
+
 import pytest
 from httpx import ASGITransport, AsyncClient
+
+
+def _db() -> sqlite3.Connection:
+    con = sqlite3.connect(":memory:")
+    con.row_factory = sqlite3.Row
+    con.execute(
+        "CREATE TABLE IF NOT EXISTS app_config (key TEXT PRIMARY KEY, value TEXT)"
+    )
+    return con
 
 
 @pytest.mark.asyncio
@@ -8,6 +19,7 @@ async def test_auth_status_returns_not_authenticated():
 
     app = create_app()
     state = AppState()
+    state.db_con = _db()
     app.state.ys2wl = state
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -23,6 +35,7 @@ async def test_auth_device_returns_400_without_creds():
 
     app = create_app()
     state = AppState()
+    state.db_con = _db()
     app.state.ys2wl = state
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -23,6 +23,10 @@ from ys2wl.db.repository import (
     get_pipeline_run,
     get_config,
     set_config,
+    get_ignore_entries,
+    add_ignore_entry,
+    update_ignore_entry,
+    delete_ignore_entry,
 )
 
 
@@ -43,6 +47,7 @@ def test_init_db_creates_tables(tmp_path):
     assert "routing_rules" in tables
     assert "pipeline_runs" in tables
     assert "app_config" in tables
+    assert "ignore_entries" in tables
 
 
 @pytest.fixture
@@ -130,3 +135,17 @@ def test_app_config(db_con):
     assert get_config(db_con, "test_key") == "test_value"
     assert set_config(db_con, "test_key", "updated")
     assert get_config(db_con, "test_key") == "updated"
+
+
+def test_ignore_entries(db_con):
+    assert get_ignore_entries(db_con, "subscription") == []
+    eid = add_ignore_entry(db_con, "subscription", "test-channel")
+    assert eid is not None
+    entries = get_ignore_entries(db_con, "subscription")
+    assert len(entries) == 1
+    assert entries[0]["pattern"] == "test-channel"
+    assert update_ignore_entry(db_con, eid, "updated-channel")
+    entries = get_ignore_entries(db_con, "subscription")
+    assert entries[0]["pattern"] == "updated-channel"
+    assert delete_ignore_entry(db_con, eid)
+    assert get_ignore_entries(db_con, "subscription") == []

--- a/ui/index.html
+++ b/ui/index.html
@@ -137,6 +137,9 @@ label { display: block; font-size: 0.875rem; color: var(--text2); margin-bottom:
   vertical-align: middle; margin-right: 0.5rem;
 }
 @keyframes spin { to { transform: rotate(360deg); } }
+.config-tab { background:var(--surface2); color:var(--text); border:none; padding:0.5rem 1rem; border-radius:var(--radius); font-weight:600; font-size:0.875rem; cursor:pointer; }
+.config-tab.active { background:var(--accent); color:#0f172a; }
+.config-pane { max-width:520px; }
 </style>
 </head>
 <body>
@@ -205,8 +208,14 @@ label { display: block; font-size: 0.875rem; color: var(--text2); margin-bottom:
   </section>
   <section id="config" class="page">
     <h2>Config</h2>
-    <div style="max-width:480px" id="configForm"></div>
-    <button id="configSave" style="margin-top:0.5rem">Save Config</button>
+    <div style="display:flex;gap:0.5rem;flex-wrap:wrap;margin-bottom:1rem">
+      <button class="config-tab active" data-tab="runtime">Runtime</button>
+      <button class="config-tab" data-tab="credentials">Credentials</button>
+      <button class="config-tab" data-tab="ignores">Ignore Lists</button>
+    </div>
+    <div id="configRuntime" class="config-pane"></div>
+    <div id="configCredentials" class="config-pane" style="display:none"></div>
+    <div id="configIgnores" class="config-pane" style="display:none"></div>
   </section>
   <section id="runs" class="page">
     <h2>Pipeline Runs</h2>
@@ -466,9 +475,9 @@ document.getElementById('ruleSave')?.addEventListener('click', async function() 
   } catch (e) { showToast('Save failed: ' + e.message); }
 });
 
-// ---- Config renderer ----
-renderers.config = async function() {
-  const container = document.getElementById('configForm');
+// ---- Config renderers ----
+renderers.configRuntime = async function() {
+  const container = document.getElementById('configRuntime');
   container.innerHTML = '<p style="color:var(--text2)">Loading...</p>';
   try {
     const cfg = await api('/api/config');
@@ -481,21 +490,130 @@ renderers.config = async function() {
       ['pipeline_concurrency', 'Pipeline Concurrency', 'number'],
       ['activity_limit', 'Activity Limit', 'number'],
       ['subscription_limit', 'Subscription Limit', 'number'],
+      ['minimum_length', 'Minimum Length', 'text'],
+      ['maximum_length', 'Maximum Length', 'text'],
+      ['published_after', 'Published After (ISO date)', 'text'],
+      ['no_webbrowser', 'No Webbrowser', 'checkbox'],
       ['log_level', 'Log Level', 'text'],
     ];
     container.innerHTML = fields.map(([key, label, type]) =>
-      `<div class="form-group"><label>${label}</label>
-      <input type="${type}" id="cfg_${key}" value="${escapeHtml(String(cfg[key] ?? ''))}"></div>`
-    ).join('');
-    document.getElementById('configSave').onclick = async function() {
+      type === 'checkbox'
+        ? `<div class="form-group"><label style="display:flex;align-items:center;gap:0.5rem;cursor:pointer">
+            <input type="checkbox" id="cfg_${key}" ${cfg[key] ? 'checked' : ''} style="width:auto">
+            ${label}</label></div>`
+        : `<div class="form-group"><label>${label}</label>
+            <input type="${type}" id="cfg_${key}" value="${escapeHtml(String(cfg[key] ?? ''))}"></div>`
+    ).join('') + '<button id="configSaveRuntime" style="margin-top:0.5rem">Save Config</button>';
+    document.getElementById('configSaveRuntime').onclick = async function() {
       const body = {};
-      fields.forEach(([key]) => { body[key] = document.getElementById('cfg_' + key).value; });
+      fields.forEach(([key]) => {
+        const el = document.getElementById('cfg_' + key);
+        if (el.type === 'checkbox') {
+          body[key] = el.checked;
+        } else {
+          body[key] = el.value;
+        }
+      });
       try {
         await api('/api/config', { method: 'PUT', body: JSON.stringify(body) });
         showToast('Config saved', 'success');
       } catch (e) { showToast('Save failed: ' + e.message); }
     };
   } catch { container.innerHTML = '<p style="color:var(--error)">Failed to load config</p>'; }
+};
+
+renderers.configCredentials = async function() {
+  const container = document.getElementById('configCredentials');
+  container.innerHTML = '<p style="color:var(--text2)">Loading...</p>';
+  try {
+    const cfg = await api('/api/config');
+    container.innerHTML = `
+      <div class="card"><h3>Client Secret JSON</h3>
+      <p style="color:var(--text2);font-size:0.75rem;margin-bottom:0.5rem">Paste the contents of your Google OAuth client_secret.json file here.</p>
+      <textarea id="cfg_client_secret_json" rows="12" style="font-family:monospace;font-size:0.75rem;width:100%;background:var(--bg);color:var(--text);border:1px solid var(--surface2);padding:0.5rem;border-radius:var(--radius)">${escapeHtml(cfg.client_secret_json || '')}</textarea>
+      <button id="saveCredentialsBtn" style="margin-top:0.75rem">Save Credentials</button></div>`;
+    document.getElementById('saveCredentialsBtn').onclick = async () => {
+      try {
+        await api('/api/config', {
+          method: 'PUT',
+          body: JSON.stringify({ client_secret_json: document.getElementById('cfg_client_secret_json').value })
+        });
+        showToast('Credentials saved', 'success');
+      } catch (e) { showToast('Save failed: ' + e.message); }
+    };
+  } catch { container.innerHTML = '<p style="color:var(--error)">Failed to load</p>'; }
+};
+
+renderers.configIgnores = async function() {
+  let ignoreType = 'subscription';
+  const container = document.getElementById('configIgnores');
+  async function loadEntries(type) {
+    const entries = await api(`/api/config/ignores?type=${type}`);
+    document.getElementById('ignoreTableBody').innerHTML = entries.length === 0
+      ? '<tr><td style="color:var(--text2)">No entries</td><td></td></tr>'
+      : entries.map(e => `<tr>
+        <td>${escapeHtml(e.pattern)}</td>
+        <td><button class="del-ignore" data-id="${e.id}" style="background:var(--error);color:#fff;padding:0.25rem 0.5rem;font-size:0.75rem;border:none;border-radius:4px;cursor:pointer">Del</button></td>
+      </tr>`).join('');
+    document.querySelectorAll('.del-ignore').forEach(btn => {
+      btn.onclick = async function() {
+        try {
+          await api(`/api/config/ignores/${this.dataset.id}`, { method: 'DELETE' });
+          loadEntries(ignoreType);
+        } catch (e) { showToast('Delete failed: ' + e.message); }
+      };
+    });
+  }
+  function render() {
+    container.innerHTML = `
+      <div style="display:flex;gap:0.5rem;flex-wrap:wrap;margin-bottom:1rem">
+        ${['subscription','video','words'].map(t =>
+          `<button class="config-tab ${t === ignoreType ? 'active' : ''}" data-itype="${t}">${t}</button>`
+        ).join('')}
+      </div>
+      <div class="form-group" style="display:flex;gap:0.5rem">
+        <input id="newIgnorePattern" placeholder="Add pattern..." style="flex:1">
+        <button id="addIgnoreBtn">Add</button>
+      </div>
+      <table style="width:100%"><thead><tr><th>Pattern</th><th></th></tr></thead>
+      <tbody id="ignoreTableBody"><tr><td style="color:var(--text2)">Loading...</td><td></td></tr></tbody></table>`;
+    loadEntries(ignoreType);
+  }
+  render();
+  container.addEventListener('click', e => {
+    const tab = e.target.closest('[data-itype]');
+    if (tab) { ignoreType = tab.dataset.itype; render(); }
+  });
+  container.addEventListener('click', async e => {
+    if (e.target.id === 'addIgnoreBtn') {
+      const input = document.getElementById('newIgnorePattern');
+      if (!input.value.trim()) return;
+      try {
+        await api('/api/config/ignores', {
+          method: 'POST',
+          body: JSON.stringify({ type: ignoreType, pattern: input.value.trim() })
+        });
+        input.value = '';
+        loadEntries(ignoreType);
+        showToast('Entry added', 'success');
+      } catch (e) { showToast('Add failed: ' + e.message); }
+    }
+  });
+};
+
+renderers.config = async function() {
+  renderers.configRuntime();
+  renderers.configCredentials();
+  renderers.configIgnores();
+  document.querySelectorAll('.config-tab[data-tab]').forEach(btn => {
+    btn.onclick = function() {
+      document.querySelectorAll('.config-tab').forEach(b => b.classList.remove('active'));
+      this.classList.add('active');
+      document.querySelectorAll('.config-pane').forEach(p => p.style.display = 'none');
+      const tabId = 'config' + this.dataset.tab.charAt(0).toUpperCase() + this.dataset.tab.slice(1);
+      document.getElementById(tabId).style.display = 'block';
+    };
+  });
 };
 
 // ---- Pipeline Runs renderer ----


### PR DESCRIPTION
## Summary
- Migrate runtime config from env-only to DB-persisted with UI editing
- Move ignore lists (subscription/video/words) from files to DB `ignore_entries` table
- Move OAuth credentials (client_secret.json, credentials pickle) to `app_config` table
- Expand config API with all runtime fields and ignore entry CRUD endpoints
- Add tabbed config UI: Runtime (all settings), Credentials (client_secret textarea), Ignore Lists (add/delete patterns)

## Test Plan
- [x] 103 tests passing
- [x] ruff lint/format clean