### PR TITLE
chore: add Traefik BasicAuth middleware to ingress

### DIFF
--- a/k8s-bootstrap/middleware.yaml
+++ b/k8s-bootstrap/middleware.yaml
@@ -1,0 +1,8 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: ys2wl-auth
+  namespace: seashell
+spec:
+  basicAuth:
+    secret: ys2wl-auth

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -2,9 +2,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ys2wl
+  namespace: seashell
   annotations:
     cert-manager.io/acme-challenge-type: http01
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.middlewares: seashell-ys2wl-auth@kubernetescrd
 spec:
   ingressClassName: traefik
   rules:


### PR DESCRIPTION
Adds BasicAuth middleware to the k8s ingress configuration for Traefik.