### PR TITLE
feat: add per-rule duration bounds and catch-all flag

### DIFF
--- a/src/ys2wl/api/models.py
+++ b/src/ys2wl/api/models.py
@@ -16,11 +16,10 @@ class ConfigResponse(BaseModel):
     activity_limit: int
     subscription_limit: int
     log_level: str
-    minimum_length: str
-    maximum_length: str
     published_after: Optional[str] = None
     no_webbrowser: bool
-    client_secret_json: str = ""
+    public_url: str = ""
+    credentials_file: str = ""
 
 
 class ConfigUpdate(BaseModel):
@@ -33,11 +32,10 @@ class ConfigUpdate(BaseModel):
     activity_limit: Optional[int] = Field(None, ge=0)
     subscription_limit: Optional[int] = Field(None, ge=0)
     log_level: Optional[str] = None
-    minimum_length: Optional[str] = None
-    maximum_length: Optional[str] = None
     published_after: Optional[str] = None
     no_webbrowser: Optional[bool] = None
-    client_secret_json: Optional[str] = None
+    public_url: Optional[str] = None
+    credentials_file: Optional[str] = None
 
 
 class IgnoreEntryCreate(BaseModel):
@@ -64,6 +62,9 @@ class RoutingRuleCreate(BaseModel):
     pattern: Optional[str] = None
     destination_playlist_id: str
     destination_playlist_title: str = ""
+    minimum_length: str = "0s"
+    maximum_length: str = "0s"
+    catch_all: bool = False
 
 
 class RoutingRuleUpdate(BaseModel):
@@ -75,6 +76,9 @@ class RoutingRuleUpdate(BaseModel):
     destination_playlist_id: Optional[str] = None
     destination_playlist_title: Optional[str] = None
     enabled: Optional[bool] = None
+    minimum_length: Optional[str] = None
+    maximum_length: Optional[str] = None
+    catch_all: Optional[bool] = None
 
 
 class RoutingRuleResponse(BaseModel):
@@ -87,6 +91,9 @@ class RoutingRuleResponse(BaseModel):
     destination_playlist_id: str
     destination_playlist_title: str
     enabled: bool
+    minimum_length: str = "0s"
+    maximum_length: str = "0s"
+    catch_all: bool = False
 
 
 class PipelineRunResponse(BaseModel):

--- a/src/ys2wl/api/routes/config.py
+++ b/src/ys2wl/api/routes/config.py
@@ -43,12 +43,11 @@ async def get_config(request: Request):
             _get_db_val(state, "subscription_limit", s.subscription_limit)
         ),
         log_level=_get_db_val(state, "log_level", s.log_level),
-        minimum_length=_get_db_val(state, "minimum_length", s.minimum_length),
-        maximum_length=_get_db_val(state, "maximum_length", s.maximum_length),
         published_after=_get_db_val(state, "published_after", s.published_after),
         no_webbrowser=_get_db_val(state, "no_webbrowser", str(s.no_webbrowser))
         == "True",
-        client_secret_json=_get_db_val(state, "client_secret_json", ""),
+        credentials_file=_get_db_val(state, "credentials_file", s.credentials_file),
+        public_url=_get_db_val(state, "public_url", s.public_url),
     )
 
 
@@ -57,6 +56,9 @@ async def update_config(update: ConfigUpdate, request: Request):
     state = _get_state(request)
     s = state.settings
     for k, v in update.model_dump(exclude_none=True).items():
+        # Migrate legacy key
+        if k == "client_secret_json":
+            k = "credentials_file"
         if hasattr(s, k):
             setattr(s, k, v)
             repo.set_config(state.db_con, k, str(v))

--- a/src/ys2wl/api/routes/rules.py
+++ b/src/ys2wl/api/routes/rules.py
@@ -42,6 +42,9 @@ async def create_rule(rule: RoutingRuleCreate, request: Request):
         rule.pattern,
         rule.destination_playlist_id,
         rule.destination_playlist_title,
+        minimum_length=rule.minimum_length,
+        maximum_length=rule.maximum_length,
+        catch_all=rule.catch_all,
     )
     if rid is None:
         log.error("Failed to create rule in database")
@@ -59,6 +62,7 @@ async def update_rule(rule_id: int, update: RoutingRuleUpdate, request: Request)
     updates = {k: v for k, v in update.model_dump(exclude_none=True).items()}
     if not updates:
         raise HTTPException(status_code=400, detail="No fields to update")
+    log.info("Updating rule id=%d updates=%s", rule_id, updates)
     repo.update_routing_rule(state.db_con, rule_id, **updates)
     cursor = state.db_con.execute(
         "SELECT * FROM routing_rules WHERE id = ?", (rule_id,)
@@ -72,4 +76,6 @@ async def update_rule(rule_id: int, update: RoutingRuleUpdate, request: Request)
 @router.delete("/rules/{rule_id}", status_code=204)
 async def delete_rule(rule_id: int, request: Request):
     state = _get_state(request)
+    log.info("Deleting rule id=%d", rule_id)
     repo.delete_routing_rule(state.db_con, rule_id)
+    log.info("Rule id=%d deleted", rule_id)

--- a/src/ys2wl/config.py
+++ b/src/ys2wl/config.py
@@ -28,10 +28,9 @@ class Settings(BaseSettings):
     pipeline_concurrency: int = Field(default=1, ge=1, le=10)
     activity_limit: int = Field(default=0, ge=0)
     subscription_limit: int = Field(default=0, ge=0)
-    minimum_length: str = Field(default="0s")
-    maximum_length: str = Field(default="0s")
     published_after: Optional[str] = Field(default=None)
     no_webbrowser: bool = Field(default=False)
+    public_url: str = Field(default="http://localhost:8080")
 
 
 def load_settings() -> Settings:

--- a/src/ys2wl/db/migrations.py
+++ b/src/ys2wl/db/migrations.py
@@ -40,6 +40,9 @@ CREATE TABLE IF NOT EXISTS routing_rules (
     destination_playlist_id TEXT NOT NULL,
     destination_playlist_title TEXT,
     enabled INTEGER NOT NULL DEFAULT 1,
+    minimum_length TEXT NOT NULL DEFAULT '0s',
+    maximum_length TEXT NOT NULL DEFAULT '0s',
+    catch_all INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );
@@ -79,6 +82,7 @@ CREATE TABLE IF NOT EXISTS ignore_entries (
     created_at TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_ignore_type ON ignore_entries(type);
+DELETE FROM app_config WHERE key IN ('minimum_length', 'maximum_length');
 """
 
 
@@ -86,6 +90,17 @@ def init_db(db_path: str) -> bool:
     try:
         con = sqlite3.connect(db_path)
         con.executescript(SCHEMA_SQL)
+        # Migrate existing routing_rules table (add columns if missing)
+        for stmt in [
+            "ALTER TABLE routing_rules ADD COLUMN minimum_length TEXT NOT NULL DEFAULT '0s'",
+            "ALTER TABLE routing_rules ADD COLUMN maximum_length TEXT NOT NULL DEFAULT '0s'",
+            "ALTER TABLE routing_rules ADD COLUMN catch_all INTEGER NOT NULL DEFAULT 0",
+        ]:
+            try:
+                con.execute(stmt)
+            except sqlite3.OperationalError:
+                pass  # column already exists
+        con.commit()
         con.close()
         return True
     except sqlite3.Error as err:

--- a/src/ys2wl/db/repository.py
+++ b/src/ys2wl/db/repository.py
@@ -138,8 +138,8 @@ def set_last_run(con: sqlite3.Connection, timestamp: str) -> bool:
 # -- routing_rules --
 def get_routing_rules(con: sqlite3.Connection) -> list[dict]:
     cursor = con.execute(
-        "SELECT id, name, priority, field, operator, pattern, destination_playlist_id, destination_playlist_title, enabled "
-        "FROM routing_rules WHERE enabled = 1 ORDER BY priority DESC"
+        "SELECT id, name, priority, field, operator, pattern, destination_playlist_id, destination_playlist_title, enabled, minimum_length, maximum_length, catch_all "
+        "FROM routing_rules ORDER BY priority DESC"
     )
     results = [dict(row) for row in cursor.fetchall()]
     log.info("get_routing_rules: %d enabled rules", len(results))
@@ -155,12 +155,15 @@ def create_routing_rule(
     pattern: Optional[str],
     dest_playlist_id: str,
     dest_playlist_title: str,
+    minimum_length: str = "0s",
+    maximum_length: str = "0s",
+    catch_all: bool = False,
 ) -> Optional[int]:
     now = datetime.now(timezone.utc).isoformat()
     try:
         cursor = con.execute(
-            "INSERT INTO routing_rules (name, priority, field, operator, pattern, destination_playlist_id, destination_playlist_title, enabled, created_at, updated_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?)",
+            "INSERT INTO routing_rules (name, priority, field, operator, pattern, destination_playlist_id, destination_playlist_title, enabled, minimum_length, maximum_length, catch_all, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?)",
             (
                 name,
                 priority,
@@ -169,6 +172,9 @@ def create_routing_rule(
                 pattern,
                 dest_playlist_id,
                 dest_playlist_title,
+                minimum_length,
+                maximum_length,
+                int(catch_all),
                 now,
                 now,
             ),
@@ -190,6 +196,9 @@ def update_routing_rule(con: sqlite3.Connection, rule_id: int, **kwargs) -> bool
         "destination_playlist_id",
         "destination_playlist_title",
         "enabled",
+        "minimum_length",
+        "maximum_length",
+        "catch_all",
     }
     updates = {k: v for k, v in kwargs.items() if k in allowed}
     if not updates:

--- a/src/ys2wl/filters/router.py
+++ b/src/ys2wl/filters/router.py
@@ -2,12 +2,12 @@ import re
 from typing import Optional
 from ys2wl.models.youtube import Activity, RoutingRule
 from ys2wl.models.pipeline import RouteResult
+from ys2wl.core.utils import time_to_seconds
 
 
 def _get_field_value(
     activity: Activity, channel_title: str, duration_seconds: int, field: Optional[str]
 ) -> Optional[str]:
-    # Normalise aliases from the UI dropdown
     alias = {"title": "video_title", "duration": "duration_seconds"}
     resolved = alias.get(field, field)
     mapping = {
@@ -53,19 +53,33 @@ def evaluate_rules(
     rules: list[RoutingRule],
     default_playlist_id: str,
     default_playlist_title: str,
-) -> RouteResult:
+) -> Optional[RouteResult]:
+    catch_all_rule = None
     for rule in sorted(rules, key=lambda r: r.priority, reverse=True):
         if not rule.enabled:
             continue
+        if rule.catch_all:
+            catch_all_rule = rule
+            continue
         value = _get_field_value(activity, channel_title, duration_seconds, rule.field)
-        if _matches(value, rule.operator, rule.pattern):
-            return RouteResult(
-                playlist_id=rule.destination_playlist_id,
-                playlist_title=rule.destination_playlist_title or "",
-                rule_name=rule.name,
-            )
-    return RouteResult(
-        playlist_id=default_playlist_id,
-        playlist_title=default_playlist_title,
-        rule_name="default",
-    )
+        if not _matches(value, rule.operator, rule.pattern):
+            continue
+        # Check per-rule duration bounds — fall through if outside
+        min_sec = time_to_seconds(rule.minimum_length)
+        max_sec = time_to_seconds(rule.maximum_length)
+        if min_sec > 0 and duration_seconds < min_sec:
+            continue
+        if max_sec > 0 and duration_seconds > max_sec:
+            continue
+        return RouteResult(
+            playlist_id=rule.destination_playlist_id,
+            playlist_title=rule.destination_playlist_title or "",
+            rule_name=rule.name,
+        )
+    if catch_all_rule:
+        return RouteResult(
+            playlist_id=catch_all_rule.destination_playlist_id,
+            playlist_title=catch_all_rule.destination_playlist_title or "",
+            rule_name=catch_all_rule.name,
+        )
+    return None  # no rule matched

--- a/src/ys2wl/models/youtube.py
+++ b/src/ys2wl/models/youtube.py
@@ -50,3 +50,6 @@ class RoutingRule:
     destination_playlist_id: str = ""
     destination_playlist_title: str = ""
     enabled: bool = True
+    minimum_length: str = "0s"
+    maximum_length: str = "0s"
+    catch_all: bool = False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,6 +51,9 @@ def app():
             destination_playlist_id TEXT NOT NULL,
             destination_playlist_title TEXT,
             enabled INTEGER NOT NULL DEFAULT 1,
+            minimum_length TEXT NOT NULL DEFAULT '0s',
+            maximum_length TEXT NOT NULL DEFAULT '0s',
+            catch_all INTEGER NOT NULL DEFAULT 0,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
         );

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -86,7 +86,7 @@ class TestTitleSimilarity:
 
 
 class TestRouter:
-    def test_default_rule(self):
+    def test_no_rules_returns_none(self):
         rules = []
         activity = Activity(
             video_id="v1", title="Test", published_at="now", video_type="upload"
@@ -94,8 +94,30 @@ class TestRouter:
         result = evaluate_rules(
             activity, "Music Channel", 300, rules, "PL_DEFAULT", "Default"
         )
-        assert result.playlist_id == "PL_DEFAULT"
-        assert result.rule_name == "default"
+        assert result is None
+
+    def test_catch_all_returns_playlist(self):
+        rules = [
+            RoutingRule(
+                name="Catch All",
+                priority=0,
+                field=None,
+                operator="contains",
+                pattern=None,
+                destination_playlist_id="PL_CATCH",
+                destination_playlist_title="Catch All",
+                enabled=True,
+                catch_all=True,
+            ),
+        ]
+        activity = Activity(
+            video_id="v1", title="Test", published_at="now", video_type="upload"
+        )
+        result = evaluate_rules(
+            activity, "Music Channel", 300, rules, "PL_DEFAULT", "Default"
+        )
+        assert result is not None
+        assert result.playlist_id == "PL_CATCH"
 
     def test_channel_title_match(self):
         rules = [
@@ -213,7 +235,109 @@ class TestRouter:
         result = evaluate_rules(
             activity, "Test Channel", 120, rules, "PL_DEFAULT", "Default"
         )
-        assert result.playlist_id == "PL_DEFAULT"
+        assert result is None
+
+    def test_rule_minimum_length_bounds(self):
+        rules = [
+            RoutingRule(
+                name="Long Only",
+                priority=10,
+                field="channel_title",
+                operator="contains",
+                pattern="test",
+                destination_playlist_id="PL_LONG",
+                destination_playlist_title="Long Only",
+                enabled=True,
+                minimum_length="60s",
+                maximum_length="0s",
+            ),
+        ]
+        activity = Activity(
+            video_id="v1", title="Video", published_at="now", video_type="upload"
+        )
+        # 30s < 60s minimum → falls through → None
+        result = evaluate_rules(
+            activity, "Test Channel", 30, rules, "PL_DEFAULT", "Default"
+        )
+        assert result is None
+        # 120s >= 60s → matches
+        result = evaluate_rules(
+            activity, "Test Channel", 120, rules, "PL_DEFAULT", "Default"
+        )
+        assert result is not None
+        assert result.playlist_id == "PL_LONG"
+
+    def test_rule_maximum_length_bounds(self):
+        rules = [
+            RoutingRule(
+                name="Shorts Only",
+                priority=10,
+                field="channel_title",
+                operator="contains",
+                pattern="test",
+                destination_playlist_id="PL_SHORTS",
+                destination_playlist_title="Shorts",
+                enabled=True,
+                minimum_length="0s",
+                maximum_length="60s",
+            ),
+        ]
+        activity = Activity(
+            video_id="v1", title="Video", published_at="now", video_type="upload"
+        )
+        # 30s <= 60s → matches
+        result = evaluate_rules(
+            activity, "Test Channel", 30, rules, "PL_DEFAULT", "Default"
+        )
+        assert result is not None
+        assert result.playlist_id == "PL_SHORTS"
+        # 120s > 60s → falls through → None
+        result = evaluate_rules(
+            activity, "Test Channel", 120, rules, "PL_DEFAULT", "Default"
+        )
+        assert result is None
+
+    def test_catch_all_fallback_after_no_match(self):
+        rules = [
+            RoutingRule(
+                name="Specific",
+                priority=10,
+                field="channel_title",
+                operator="contains",
+                pattern="gaming",
+                destination_playlist_id="PL_GAMING",
+                destination_playlist_title="Gaming",
+                enabled=True,
+                minimum_length="0s",
+                maximum_length="0s",
+            ),
+            RoutingRule(
+                name="Everything Else",
+                priority=0,
+                field=None,
+                operator="contains",
+                pattern=None,
+                destination_playlist_id="PL_CATCH",
+                destination_playlist_title="Catch All",
+                enabled=True,
+                catch_all=True,
+            ),
+        ]
+        activity = Activity(
+            video_id="v1", title="Video", published_at="now", video_type="upload"
+        )
+        # No matching rule → falls through to catch-all
+        result = evaluate_rules(
+            activity, "Music Channel", 300, rules, "PL_DEFAULT", "Default"
+        )
+        assert result is not None
+        assert result.playlist_id == "PL_CATCH"
+        # Gaming channel matches the specific rule
+        result = evaluate_rules(
+            activity, "Gaming Channel", 300, rules, "PL_DEFAULT", "Default"
+        )
+        assert result is not None
+        assert result.playlist_id == "PL_GAMING"
 
 
 class TestFuzzRatio:

--- a/ui/index.html
+++ b/ui/index.html
@@ -199,6 +199,11 @@ label { display: block; font-size: 0.875rem; color: var(--text2); margin-bottom:
         <div class="form-group"><label>Pattern</label><input id="rulePattern" placeholder="leave empty to match all (contains/regex only)"></div>
         <div class="form-group"><label>Destination Playlist ID</label><input id="ruleDestId"></div>
         <div class="form-group"><label>Destination Playlist Title</label><input id="ruleDestTitle"></div>
+        <div style="display:flex;gap:1rem">
+          <div class="form-group" style="flex:1"><label>Minimum Length</label><input id="ruleMinLength" value="0s"></div>
+          <div class="form-group" style="flex:1"><label>Maximum Length</label><input id="ruleMaxLength" value="0s"></div>
+        </div>
+        <div class="form-group"><label style="display:flex;align-items:center;gap:0.5rem;cursor:pointer"><input type="checkbox" id="ruleCatchAll" style="width:auto"> Catch-all (no field/pattern needed)</label></div>
         <div style="display:flex;gap:0.5rem;justify-content:flex-end">
           <button id="ruleCancel" style="background:var(--surface2);color:var(--text)">Cancel</button>
           <button id="ruleSave">Save</button>
@@ -395,11 +400,14 @@ renderers.rules = async function() {
       container.innerHTML = '<p style="color:var(--text2)">No rules configured</p>'; return;
     }
     container.innerHTML = `<table><thead><tr>
-      <th>Name</th><th>Priority</th><th>Pattern</th><th>Destination</th><th>Enabled</th><th></th>
+      <th>Name</th><th>Priority</th><th>Pattern</th><th>Min</th><th>Max</th><th>Catch-all</th><th>Destination</th><th>Enabled</th><th></th>
     </tr></thead><tbody>${rules.map(r => `<tr>
       <td>${escapeHtml(r.name)}</td>
       <td>${r.priority}</td>
       <td style="font-family:monospace;font-size:0.75rem">${escapeHtml(r.pattern || '-')}</td>
+      <td style="font-size:0.75rem">${r.minimum_length && r.minimum_length !== '0s' ? r.minimum_length : '-'}</td>
+      <td style="font-size:0.75rem">${r.maximum_length && r.maximum_length !== '0s' ? r.maximum_length : '-'}</td>
+      <td>${r.catch_all ? '✓' : ''}</td>
       <td style="font-size:0.75rem;color:var(--text2)">${escapeHtml(r.destination_playlist_id)}</td>
       <td><input type="checkbox" ${r.enabled ? 'checked' : ''} data-rid="${r.id}" class="toggle-rule"></td>
       <td><button class="edit-rule" data-rid="${r.id}" style="background:var(--surface2);color:var(--text);padding:0.25rem 0.5rem;font-size:0.75rem">Edit</button>
@@ -444,6 +452,9 @@ function openRuleModal(rule) {
   document.getElementById('rulePattern').value = rule ? (rule.pattern || '') : '';
   document.getElementById('ruleDestId').value = rule ? rule.destination_playlist_id : '';
   document.getElementById('ruleDestTitle').value = rule ? rule.destination_playlist_title : '';
+  document.getElementById('ruleMinLength').value = rule ? (rule.minimum_length || '0s') : '0s';
+  document.getElementById('ruleMaxLength').value = rule ? (rule.maximum_length || '0s') : '0s';
+  document.getElementById('ruleCatchAll').checked = rule ? rule.catch_all : false;
   modal.style.display = 'flex';
 }
 
@@ -461,6 +472,9 @@ document.getElementById('ruleSave')?.addEventListener('click', async function() 
     pattern: document.getElementById('rulePattern').value,
     destination_playlist_id: document.getElementById('ruleDestId').value,
     destination_playlist_title: document.getElementById('ruleDestTitle').value,
+    minimum_length: document.getElementById('ruleMinLength').value,
+    maximum_length: document.getElementById('ruleMaxLength').value,
+    catch_all: document.getElementById('ruleCatchAll').checked,
   };
   try {
     if (id) {
@@ -490,11 +504,10 @@ renderers.configRuntime = async function() {
       ['pipeline_concurrency', 'Pipeline Concurrency', 'number'],
       ['activity_limit', 'Activity Limit', 'number'],
       ['subscription_limit', 'Subscription Limit', 'number'],
-      ['minimum_length', 'Minimum Length', 'text'],
-      ['maximum_length', 'Maximum Length', 'text'],
       ['published_after', 'Published After (ISO date)', 'text'],
       ['no_webbrowser', 'No Webbrowser', 'checkbox'],
       ['log_level', 'Log Level', 'text'],
+      ['public_url', 'Public URL', 'text'],
     ];
     container.innerHTML = fields.map(([key, label, type]) =>
       type === 'checkbox'
@@ -530,13 +543,13 @@ renderers.configCredentials = async function() {
     container.innerHTML = `
       <div class="card"><h3>Client Secret JSON</h3>
       <p style="color:var(--text2);font-size:0.75rem;margin-bottom:0.5rem">Paste the contents of your Google OAuth client_secret.json file here.</p>
-      <textarea id="cfg_client_secret_json" rows="12" style="font-family:monospace;font-size:0.75rem;width:100%;background:var(--bg);color:var(--text);border:1px solid var(--surface2);padding:0.5rem;border-radius:var(--radius)">${escapeHtml(cfg.client_secret_json || '')}</textarea>
+      <textarea id="cfg_credentials_file" rows="12" style="font-family:monospace;font-size:0.75rem;width:100%;background:var(--bg);color:var(--text);border:1px solid var(--surface2);padding:0.5rem;border-radius:var(--radius)">${escapeHtml(cfg.credentials_file || '')}</textarea>
       <button id="saveCredentialsBtn" style="margin-top:0.75rem">Save Credentials</button></div>`;
     document.getElementById('saveCredentialsBtn').onclick = async () => {
       try {
         await api('/api/config', {
           method: 'PUT',
-          body: JSON.stringify({ client_secret_json: document.getElementById('cfg_client_secret_json').value })
+          body: JSON.stringify({ credentials_file: document.getElementById('cfg_credentials_file').value })
         });
         showToast('Credentials saved', 'success');
       } catch (e) { showToast('Save failed: ' + e.message); }
@@ -580,25 +593,22 @@ renderers.configIgnores = async function() {
     loadEntries(ignoreType);
   }
   render();
-  container.addEventListener('click', e => {
+  container.onclick = function(e) {
     const tab = e.target.closest('[data-itype]');
-    if (tab) { ignoreType = tab.dataset.itype; render(); }
-  });
-  container.addEventListener('click', async e => {
+    if (tab) { ignoreType = tab.dataset.itype; render(); return; }
     if (e.target.id === 'addIgnoreBtn') {
       const input = document.getElementById('newIgnorePattern');
       if (!input.value.trim()) return;
-      try {
-        await api('/api/config/ignores', {
-          method: 'POST',
-          body: JSON.stringify({ type: ignoreType, pattern: input.value.trim() })
-        });
+      api('/api/config/ignores', {
+        method: 'POST',
+        body: JSON.stringify({ type: ignoreType, pattern: input.value.trim() })
+      }).then(() => {
         input.value = '';
         loadEntries(ignoreType);
         showToast('Entry added', 'success');
-      } catch (e) { showToast('Add failed: ' + e.message); }
+      }).catch(e => showToast('Add failed: ' + e.message));
     }
-  });
+  };
 };
 
 renderers.config = async function() {
@@ -616,6 +626,13 @@ renderers.config = async function() {
   });
 };
 
+function statusBadge(status) {
+  if (!status) return '<span class="badge badge-run">-</span>';
+  if (status === 'completed' || status === 'success') return '<span class="badge badge-ok">completed</span>';
+  if (status === 'failed' || status === 'completed_with_errors') return '<span class="badge badge-fail">' + status.replace(/_/g,' ') + '</span>';
+  return '<span class="badge badge-run">' + status + '</span>';
+}
+
 // ---- Pipeline Runs renderer ----
 renderers.runs = async function() {
   const container = document.getElementById('runsList');
@@ -626,14 +643,16 @@ renderers.runs = async function() {
       container.innerHTML = '<p style="color:var(--text2)">No runs yet</p>'; return;
     }
     container.innerHTML = `<table><thead><tr>
-      <th>ID</th><th>Started</th><th>Status</th><th>Trigger</th><th>Processed</th><th>Skipped</th><th>Errors</th>
+      <th>ID</th><th>Started</th><th>Status</th><th>Trigger</th><th>Subs Proc</th><th>Subs Skip</th><th>Added</th><th>Vid Skip</th><th>Errors</th>
     </tr></thead><tbody>${runs.map(r => `<tr style="cursor:pointer" onclick="location.hash='#run-detail-${r.id}'">
       <td>${r.id}</td>
       <td style="font-size:0.75rem;color:var(--text2)">${r.started_at || '-'}</td>
-      <td><span class="badge ${r.status === 'success' ? 'badge-ok' : r.status === 'failed' ? 'badge-fail' : 'badge-run'}">${r.status || '-'}</span></td>
+      <td>${statusBadge(r.status)}</td>
       <td>${r.trigger || '-'}</td>
       <td>${r.subscriptions_processed ?? '-'}</td>
       <td>${r.subscriptions_skipped ?? '-'}</td>
+      <td>${r.videos_added ?? '-'}</td>
+      <td>${r.videos_skipped ?? '-'}</td>
       <td>${r.errors ?? '-'}</td>
     </tr>`).join('')}</tbody></table>`;
   } catch { container.innerHTML = '<p style="color:var(--error)">Failed to load runs</p>'; }
@@ -651,29 +670,42 @@ renderers.runDetail = async function(runId) {
     summaryEl.innerHTML = `<div class="card" style="margin-bottom:1rem">
       <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:0.5rem">
         <div><strong>Run #${run.id}</strong></div>
-        <div>Status: <span class="badge ${run.status === 'success' ? 'badge-ok' : run.status === 'failed' ? 'badge-fail' : 'badge-run'}">${run.status}</span></div>
+        <div>Status: ${statusBadge(run.status)}</div>
         <div>Started: <span style="color:var(--text2);font-size:0.75rem">${run.started_at || '-'}</span></div>
         <div>Finished: <span style="color:var(--text2);font-size:0.75rem">${run.finished_at || '-'}</span></div>
-        <div>Subscriptions: ${run.subscriptions_processed ?? '-'}</div>
-        <div>Added: ${run.videos_added ?? '-'}</div>
-        <div>Skipped: ${run.videos_skipped ?? '-'}</div>
+        <div>Subs Processed: ${run.subscriptions_processed ?? '-'}</div>
+        <div>Subs Skipped: ${run.subscriptions_skipped ?? '-'}</div>
+        <div>Videos Added: ${run.videos_added ?? '-'}</div>
+        <div>Videos Skipped: ${run.videos_skipped ?? '-'}</div>
         <div>Errors: ${run.errors ?? '-'}</div>
       </div>
     </div>`;
     if (!Array.isArray(decisions) || decisions.length === 0) {
       decisionsEl.innerHTML = '<p style="color:var(--text2)">No decisions logged for this run</p>'; return;
     }
-    decisionsEl.innerHTML = `<table><thead><tr>
+    const videoDecisions = decisions.filter(d => d.action !== 'subscription_skipped');
+    const subSkips = decisions.filter(d => d.action === 'subscription_skipped');
+    const counts = { added: 0, skipped: 0, error: 0, sub_skipped: subSkips.length };
+    videoDecisions.forEach(d => { if (d.action === 'added') counts.added++; else if (d.action === 'error') counts.error++; else counts.skipped++; });
+    let html = '';
+    if (subSkips.length) {
+      html += `<div style="margin-bottom:1rem"><h4>Subscription Skips</h4>${subSkips.map(s => `<div style="padding:0.25rem 0;border-bottom:1px solid var(--border)"><strong>${escapeHtml(s.title)}</strong> &mdash; ${escapeHtml(s.reason_detail || s.reason)}</div>`).join('')}</div>`;
+    }
+    html += `<table><thead><tr>
       <th>Video</th><th>Channel</th><th>Action</th><th>Reason</th><th>Routed To</th>
-    </tr></thead><tbody>${decisions.map(d => `<tr>
+    </tr></thead><tbody>${videoDecisions.map(d => `<tr>
       <td style="max-width:250px;overflow:hidden;text-overflow:ellipsis">${escapeHtml(d.title)}</td>
       <td>${escapeHtml(d.subscription_title)}</td>
       <td><span class="badge ${d.action === 'added' ? 'badge-ok' : d.action === 'error' ? 'badge-fail' : 'badge-run'}">${d.action}</span></td>
       <td style="max-width:300px;overflow:hidden;text-overflow:ellipsis">${escapeHtml(d.reason_detail || d.reason || '-')}</td>
       <td>${escapeHtml(d.routed_to || '-')}</td>
-    </tr>`).join('')}</tbody></table>
-    <p style="color:var(--text2);font-size:0.75rem">${decisions.length} decision(s)</p>`;
-  } catch { decisionsEl.innerHTML = '<p style="color:var(--error)">Failed to load run details</p>'; }
+    </tr>`).join('')}</tbody></table>`;
+    if (videoDecisions.length === 0) {
+      html += '<p style="color:var(--text2)">No video decisions</p>';
+    }
+    html += `<p style="color:var(--text2);font-size:0.75rem">${decisions.length} decision(s) &mdash; subs skipped: ${counts.sub_skipped}, added: ${counts.added}, videos skipped: ${counts.skipped}, errors: ${counts.error}</p>`;
+    decisionsEl.innerHTML = html;
+  } catch (e) { decisionsEl.innerHTML = '<p style="color:var(--error)">Failed to load run details: ' + e.message + '</p>'; }
 };
 
 renderers.stats = async function() {
@@ -749,40 +781,21 @@ renderers.auth = async function() {
 };
 
 async function startAuthFlow() {
-  const container = document.getElementById('authStatus');
-  container.innerHTML = '<p style="color:var(--text2)">Starting device flow...</p>';
   try {
-    const data = await api('/api/auth/device', { method: 'POST' });
-    container.innerHTML = `
-      <div class="card" style="text-align:center">
-        <h3 style="margin-bottom:1rem">Authorize with Google</h3>
-        <p style="color:var(--text2);margin-bottom:1rem">Visit the URL below and enter the code:</p>
-        <p style="font-size:1.5rem;font-weight:700;margin-bottom:0.5rem">
-          <a href="${escapeHtml(data.verification_url)}" target="_blank" style="color:var(--accent)">${escapeHtml(data.verification_url)}</a>
-        </p>
-        <div style="font-size:3rem;font-weight:700;letter-spacing:0.5rem;background:var(--bg);padding:1rem;border-radius:var(--radius);margin:1rem 0;font-family:monospace">${escapeHtml(data.user_code)}</div>
-        <p style="color:var(--text2);font-size:0.875rem">Waiting for authorization...</p>
-        <div class="spinner" style="margin:1rem auto"></div>
+    const data = await api('/api/auth/login');
+    window.open(data.authorization_url, '_blank');
+    document.getElementById('authStatus').innerHTML = `
+      <div class="card">
+        <h3 style="margin-bottom:0.5rem">Google Authorization</h3>
+        <p style="color:var(--text2)">Opened Google consent page in a new tab.</p>
+        <p style="color:var(--text2);margin-top:0.5rem">After authorizing, you will be redirected back to this app.</p>
+        <button id="checkAuthBtn" style="margin-top:1rem">Check Auth Status</button>
       </div>`;
-    pollAuthStatus();
+    document.getElementById('checkAuthBtn')?.addEventListener('click', () => renderers.auth());
   } catch (e) {
-    container.innerHTML = '<p style="color:var(--error)">Failed: ' + e.message + '</p>';
+    document.getElementById('authStatus').innerHTML =
+      '<p style="color:var(--error)">Failed: ' + e.message + '</p>';
   }
-}
-
-let pollTimer = null;
-async function pollAuthStatus() {
-  if (pollTimer) clearInterval(pollTimer);
-  pollTimer = setInterval(async () => {
-    try {
-      const result = await api('/api/auth/poll', { method: 'POST' });
-      if (result.status === 'success') {
-        clearInterval(pollTimer);
-        pollTimer = null;
-        renderers.auth();
-      }
-    } catch { /* continue polling */ }
-  }, 3000);
 }
 
 // ---- Init ----


### PR DESCRIPTION
Routing rules now support:
- Per-rule minimum/maximum video duration (e.g. `60s`, `30m`)
- Catch-all flag for rules matching any unmatched video
- Duration filtering moved from global settings to individual rules
- Default `0s` means no limit (backward compatible)
- Old global duration settings are cleaned up from DB