### PR TITLE
feat: replace device flow with OAuth redirect flow

### DIFF
--- a/src/ys2wl/api/routes/auth.py
+++ b/src/ys2wl/api/routes/auth.py
@@ -1,9 +1,13 @@
+import logging
 from fastapi import APIRouter, Request, HTTPException
 from pydantic import BaseModel
+from fastapi.responses import RedirectResponse
+
+log = logging.getLogger("ys2wl.auth_routes")
 from ys2wl.core.auth import (
     get_client_config,
-    start_device_flow,
-    poll_device_flow,
+    get_authorization_url,
+    exchange_code_for_tokens,
     save_credentials,
     credentials_status,
 )
@@ -12,16 +16,8 @@ from ys2wl.core.youtube import YouTubeAPIClient
 router = APIRouter()
 
 
-class DeviceFlowResponse(BaseModel):
-    user_code: str
-    verification_url: str
-    device_code: str
-    interval: int
-
-
-class PollResponse(BaseModel):
-    status: str
-    error: str | None = None
+class AuthLoginResponse(BaseModel):
+    authorization_url: str
 
 
 class StatusResponse(BaseModel):
@@ -39,44 +35,35 @@ async def auth_status(request: Request):
     return credentials_status(state.credentials)
 
 
-@router.post("/auth/device", response_model=DeviceFlowResponse)
-async def auth_device(request: Request):
+@router.get("/auth/login", response_model=AuthLoginResponse)
+async def auth_login(request: Request):
     state = _get_state(request)
     config = get_client_config(state.db_con)
     if not config or not config.get("client_id"):
         raise HTTPException(
             status_code=400, detail="credentials.json not found or invalid"
         )
-    data = start_device_flow(config["client_id"])
-    state.device_flow = {
-        "client_id": config["client_id"],
-        "client_secret": config["client_secret"],
-        "device_code": data["device_code"],
-    }
-    return DeviceFlowResponse(
-        user_code=data["user_code"],
-        verification_url=data["verification_url"],
-        device_code=data["device_code"],
-        interval=data.get("interval", 5),
-    )
+    redirect_uri = f"{state.settings.public_url}/api/auth/callback"
+    url = get_authorization_url(config, redirect_uri)
+    return AuthLoginResponse(authorization_url=url)
 
 
-@router.post("/auth/poll", response_model=PollResponse)
-async def auth_poll(request: Request):
+@router.get("/auth/callback")
+async def auth_callback(request: Request, code: str | None = None, error: str | None = None):
     state = _get_state(request)
-    if not state.device_flow:
-        raise HTTPException(
-            status_code=400, detail="No active device flow. POST /auth/device first."
-        )
-    creds, error = poll_device_flow(
-        state.device_flow["client_id"],
-        state.device_flow["client_secret"],
-        state.device_flow["device_code"],
-    )
-    if creds:
-        save_credentials(state.db_con, creds)
-        state.credentials = creds
-        state.youtube = YouTubeAPIClient(credentials=creds)
-        state.device_flow = None
-        return PollResponse(status="success")
-    return PollResponse(status=error or "pending", error=error)
+    if error:
+        log.warning("OAuth callback error: %s", error)
+        return RedirectResponse(url=f"{state.settings.public_url}/ui/index.html#auth")
+    if not code:
+        raise HTTPException(status_code=400, detail="Missing authorisation code")
+    config = get_client_config(state.db_con)
+    if not config:
+        raise HTTPException(status_code=400, detail="No client config found")
+    redirect_uri = f"{state.settings.public_url}/api/auth/callback"
+    creds = exchange_code_for_tokens(config, code, redirect_uri)
+    if not creds:
+        raise HTTPException(status_code=400, detail="Failed to exchange authorisation code")
+    save_credentials(state.db_con, creds)
+    state.credentials = creds
+    state.youtube = YouTubeAPIClient(credentials=creds)
+    return RedirectResponse(url=f"{state.settings.public_url}/ui/index.html#auth")

--- a/src/ys2wl/core/auth.py
+++ b/src/ys2wl/core/auth.py
@@ -4,6 +4,7 @@ import logging
 import pickle
 import sqlite3
 from typing import Optional
+from urllib.parse import urlencode
 from google.auth.credentials import Credentials
 from google.oauth2.credentials import Credentials as OAuth2Credentials
 from google.auth.transport.requests import Request
@@ -19,16 +20,16 @@ SCOPES = [
     "https://www.googleapis.com/auth/youtube.readonly",
 ]
 
-DEVICE_CODE_URL = "https://oauth2.googleapis.com/device/code"
+AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 TOKEN_URL = "https://oauth2.googleapis.com/token"
 
 
 def get_client_config(db_con: sqlite3.Connection) -> Optional[dict]:
     """Extract client_id and client_secret from Google OAuth credentials JSON in DB."""
     try:
-        raw = repo.get_config(db_con, "client_secret_json")
+        raw = repo.get_config(db_con, "credentials_file")
         if not raw:
-            log.error("No client_secret_json in app_config")
+            log.error("No credentials_file in app_config")
             return None
         data = json.loads(raw)
         installed = data.get("installed") or data.get("web", {})
@@ -41,51 +42,46 @@ def get_client_config(db_con: sqlite3.Connection) -> Optional[dict]:
         return None
 
 
-def start_device_flow(client_id: str) -> dict:
-    """Start OAuth 2.0 Device Flow. Returns device_code, user_code, verification_url, interval."""
-    with httpx.Client() as client:
-        resp = client.post(
-            DEVICE_CODE_URL,
-            data={
-                "client_id": client_id,
-                "scope": " ".join(SCOPES),
-            },
-        )
-        resp.raise_for_status()
-        return resp.json()
+def get_authorization_url(client_config: dict, redirect_uri: str) -> str:
+    """Build Google OAuth authorization URL for browser redirect."""
+    params = {
+        "client_id": client_config["client_id"],
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": " ".join(SCOPES),
+        "access_type": "offline",
+        "prompt": "consent",
+    }
+    return f"{AUTH_URL}?{urlencode(params)}"
 
 
-def poll_device_flow(
-    client_id: str, client_secret: str, device_code: str
-) -> tuple[Optional[Credentials], Optional[str]]:
-    """Poll Google for token. Returns (credentials, None) on success, (None, status) if pending/failed."""
+def exchange_code_for_tokens(
+    client_config: dict, code: str, redirect_uri: str
+) -> Optional[Credentials]:
+    """Exchange authorization code for OAuth credentials."""
     with httpx.Client() as client:
         resp = client.post(
             TOKEN_URL,
             data={
-                "client_id": client_id,
-                "client_secret": client_secret,
-                "device_code": device_code,
-                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "client_id": client_config["client_id"],
+                "client_secret": client_config["client_secret"],
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "grant_type": "authorization_code",
             },
         )
         data = resp.json()
-    if "access_token" in data:
-        creds = OAuth2Credentials(
-            token=data["access_token"],
-            refresh_token=data.get("refresh_token"),
-            token_uri=TOKEN_URL,
-            client_id=client_id,
-            client_secret=client_secret,
-            scopes=SCOPES,
-        )
-        return creds, None
-    error = data.get("error", "unknown")
-    if error in ("authorization_pending",):
-        return None, "pending"
-    if error == "slow_down":
-        return None, "slow_down"
-    return None, error
+    if "access_token" not in data:
+        log.error("Token exchange failed: %s", data.get("error", "unknown"))
+        return None
+    return OAuth2Credentials(
+        token=data["access_token"],
+        refresh_token=data.get("refresh_token"),
+        token_uri=TOKEN_URL,
+        client_id=client_config["client_id"],
+        client_secret=client_config["client_secret"],
+        scopes=SCOPES,
+    )
 
 
 def save_credentials(db_con: sqlite3.Connection, credentials: Credentials) -> None:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -26,7 +26,7 @@ def test_get_client_config_parses_installed():
     db_con = _db()
     repo.set_config(
         db_con,
-        "client_secret_json",
+        "credentials_file",
         json.dumps({"installed": {"client_id": "abc", "client_secret": "def"}}),
     )
     result = get_client_config(db_con)
@@ -37,7 +37,7 @@ def test_get_client_config_parses_web():
     db_con = _db()
     repo.set_config(
         db_con,
-        "client_secret_json",
+        "credentials_file",
         json.dumps({"web": {"client_id": "xyz", "client_secret": "123"}}),
     )
     result = get_client_config(db_con)

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -30,7 +30,7 @@ async def test_auth_status_returns_not_authenticated():
 
 
 @pytest.mark.asyncio
-async def test_auth_device_returns_400_without_creds():
+async def test_auth_login_returns_400_without_creds():
     from ys2wl.api.app import create_app, AppState
 
     app = create_app()
@@ -39,5 +39,5 @@ async def test_auth_device_returns_400_without_creds():
     app.state.ys2wl = state
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.post("/api/auth/device")
+        resp = await client.get("/api/auth/login")
     assert resp.status_code == 400


### PR DESCRIPTION
Replaces the Google device code authentication flow with a standard OAuth redirect flow:
- `/api/auth/login` returns authorization URL (user opens in browser)
- Removes device flow polling (`/api/auth/device`, `/api/auth/poll`)
- Renames config key from `client_secret_json` to `credentials_file`
- UI auth flow simplified to 'Open in browser → Check Auth Status'
- Tests updated for new endpoint names and config key