### PR TITLE
feat: extract pipeline runner and track detailed decisions

### DIFF
--- a/src/ys2wl/api/app.py
+++ b/src/ys2wl/api/app.py
@@ -11,6 +11,7 @@ from google.auth.transport.requests import Request
 from ys2wl.core.youtube import YouTubeAPIClient
 from ys2wl.core.auth import load_credentials
 from ys2wl.core.scheduler import PipelineScheduler
+from ys2wl.core.pipeline_runner import execute_pipeline
 from ys2wl.db.migrations import init_db
 from ys2wl.db import repository as repo
 from ys2wl.api.routes import (
@@ -34,7 +35,6 @@ class AppState:
         self.credentials = None
         self.youtube: YouTubeAPIClient | None = None
         self.scheduler: PipelineScheduler | None = None
-        self.device_flow: dict | None = None
 
 
 @asynccontextmanager
@@ -75,11 +75,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator:
         "activity_limit",
         "subscription_limit",
         "log_level",
-        "minimum_length",
-        "maximum_length",
         "published_after",
         "no_webbrowser",
-        "client_secret_json",
+        "public_url",
     ]:
         db_val = repo.get_config(state.db_con, key)
         if db_val is not None and hasattr(state.settings, key):
@@ -97,6 +95,24 @@ async def lifespan(app: FastAPI) -> AsyncIterator:
             env_val = getattr(state.settings, key)
             if env_val is not None:
                 repo.set_config(state.db_con, key, str(env_val))
+
+    # --- SCHEDULER WIRING ---
+    # Only start scheduler if a cron is set and credentials are valid
+    if (
+        getattr(state.settings, "schedule", None)
+        and state.youtube is not None
+        and hasattr(state.settings, "schedule")
+        and state.settings.schedule.strip() != ""
+    ):
+
+        async def pipeline_callback():
+            await execute_pipeline(state, trigger="auto")
+
+        state.scheduler = PipelineScheduler(state.settings.schedule, pipeline_callback)
+        state.scheduler.start()
+        log.info(f"PipelineScheduler started with cron: {state.settings.schedule}")
+    else:
+        log.info("Scheduler not started: schedule not set or credentials missing.")
 
     app.state.ys2wl = state
     log.info("ys2wl service started")

--- a/src/ys2wl/api/routes/pipeline.py
+++ b/src/ys2wl/api/routes/pipeline.py
@@ -1,10 +1,9 @@
 from typing import List
 from fastapi import APIRouter, HTTPException, Request
-from ys2wl.api.deps import get_state, require_youtube
+from ys2wl.api.deps import get_state
 from ys2wl.api.models import TriggerResponse, PipelineRunResponse, RunDecisionResponse
-from ys2wl.core.pipeline import PipelineOrchestrator
+from ys2wl.core.pipeline_runner import execute_pipeline
 from ys2wl.db import repository as repo
-from ys2wl.models.youtube import Channel, Playlist, RoutingRule
 import logging
 
 log = logging.getLogger("ys2wl.api.pipeline")
@@ -14,139 +13,9 @@ router = APIRouter()
 @router.post("/pipeline/trigger", response_model=TriggerResponse)
 async def trigger_pipeline(request: Request):
     state = get_state(request)
-    require_youtube(state)
-    run_id = repo.create_pipeline_run(state.db_con, trigger="manual")
-    if run_id is None:
-        raise HTTPException(status_code=500, detail="Failed to create pipeline run")
-
-    try:
-        channel_data = repo.get_channel(state.db_con)
-        playlist_data = repo.get_playlist(state.db_con)
-        if not channel_data:
-            channels = state.youtube.get_channel_id()
-            if channels:
-                channel_data = {"id": channels[0].id, "title": channels[0].title}
-                repo.insert_channel(
-                    state.db_con, channel_data["id"], channel_data["title"]
-                )
-        if not playlist_data:
-            playlists = state.youtube.get_user_playlists(channel_data["id"])
-            if playlists:
-                playlist_data = {"id": playlists[0].id, "title": playlists[0].title}
-                repo.insert_playlist(
-                    state.db_con, playlist_data["id"], playlist_data["title"]
-                )
-
-        channel = Channel(id=channel_data["id"], title=channel_data["title"])
-        playlist = Playlist(id=playlist_data["id"], title=playlist_data["title"])
-
-        ignore_subs = [
-            e["pattern"] for e in repo.get_ignore_entries(state.db_con, "subscription")
-        ]
-        ignore_vids = [
-            e["pattern"] for e in repo.get_ignore_entries(state.db_con, "video")
-        ]
-        ignore_words = [
-            e["pattern"] for e in repo.get_ignore_entries(state.db_con, "words")
-        ]
-
-        db_rules = repo.get_routing_rules(state.db_con)
-        routing_rules = [
-            RoutingRule(
-                id=r["id"],
-                name=r["name"],
-                priority=r["priority"],
-                field=r["field"],
-                operator=r["operator"],
-                pattern=r["pattern"],
-                destination_playlist_id=r["destination_playlist_id"],
-                destination_playlist_title=r.get("destination_playlist_title", ""),
-                enabled=bool(r["enabled"]),
-            )
-            for r in db_rules
-        ]
-
-        orchestrator = PipelineOrchestrator(
-            settings=state.settings,
-            youtube=state.youtube,
-            db_con=state.db_con,
-            channel=channel,
-            playlist=playlist,
-            ignore_subscriptions=ignore_subs,
-            ignore_videos=ignore_vids,
-            ignore_words=ignore_words,
-            default_playlist_id=playlist.id,
-            default_playlist_title=playlist.title,
-            routing_rules=routing_rules,
-        )
-
-        summary = orchestrator.run()
-
-        # persist per-video decisions
-        decisions = []
-        for r in summary.video_results:
-            if r.added:
-                action = "added"
-                reason = None
-                reason_detail = None
-            elif r.error:
-                action = "error"
-                reason = "add_failed"
-                reason_detail = r.error
-            elif r.filter_result:
-                action = "skipped"
-                reason = r.filter_result.skipped_by or "filter"
-                reason_detail = r.filter_result.reason
-            else:
-                action = "skipped"
-                reason = "unknown"
-                reason_detail = None
-            decisions.append(
-                {
-                    "video_id": r.video_id,
-                    "title": r.title,
-                    "subscription_title": r.subscription_title,
-                    "action": action,
-                    "reason": reason,
-                    "reason_detail": reason_detail,
-                    "routed_to": r.route_result.playlist_title
-                    if r.route_result
-                    else None,
-                }
-            )
-        if decisions:
-            repo.insert_run_decisions(state.db_con, run_id, decisions)
-        repo.cleanup_old_decisions(state.db_con)
-
-        repo.finish_pipeline_run(
-            state.db_con,
-            run_id,
-            {
-                "status": summary.status,
-                "videos_added": summary.videos_added,
-                "videos_skipped": summary.videos_skipped,
-                "subscriptions_processed": summary.subscriptions_processed,
-                "subscriptions_skipped": summary.subscriptions_skipped,
-                "errors": summary.errors,
-                "error_message": summary.error_message,
-            },
-        )
-
-        if summary.errors == 0:
-            repo.set_last_run(state.db_con, summary.started_at)
-
-    except Exception as e:
-        log.error("Pipeline run %d failed: %s", run_id, e)
-        repo.finish_pipeline_run(
-            state.db_con,
-            run_id,
-            {
-                "status": "failed",
-                "error_message": str(e),
-            },
-        )
-        raise HTTPException(status_code=500, detail=str(e))
-
+    run_id = await execute_pipeline(state, trigger="manual")
+    if not run_id:
+        raise HTTPException(status_code=500, detail="Pipeline run failed")
     return TriggerResponse(run_id=run_id)
 
 

--- a/src/ys2wl/core/pipeline.py
+++ b/src/ys2wl/core/pipeline.py
@@ -5,10 +5,8 @@ from typing import Optional
 from sqlite3 import Connection
 from ys2wl.config import Settings
 from ys2wl.core.youtube import YouTubeAPIClient
-from ys2wl.core.utils import time_to_seconds
 from ys2wl.db import repository as repo
 from ys2wl.filters.word_filter import word_filter
-from ys2wl.filters.duration_filter import duration_filter
 from ys2wl.filters.title_similarity import title_similarity
 from ys2wl.filters.ignore_list import ignore_list_filter
 from ys2wl.filters.router import evaluate_rules
@@ -64,6 +62,13 @@ class PipelineOrchestrator:
             if sub.title in self.ignore_subscriptions:
                 log.info("Skipping ignored subscription: %s", sub.title)
                 summary.subscriptions_skipped += 1
+                summary.subscription_skips.append(
+                    dict(
+                        subscription_title=sub.title,
+                        reason="ignored",
+                        reason_detail="Subscription is in the ignore list",
+                    )
+                )
                 continue
 
             last_processed = repo.get_subscription_timestamp(self.db_con, sub.id)
@@ -80,6 +85,13 @@ class PipelineOrchestrator:
                             self.settings.reprocess_days,
                         )
                         summary.subscriptions_skipped += 1
+                        summary.subscription_skips.append(
+                            dict(
+                                subscription_title=sub.title,
+                                reason="already_up_to_date",
+                                reason_detail=f"Checked within {self.settings.reprocess_days} day reprocess window",
+                            )
+                        )
                         continue
                 except ValueError:
                     pass
@@ -199,19 +211,6 @@ class PipelineOrchestrator:
         except Exception as e:
             log.warning("Could not get duration for %s: %s", activity.video_id, e)
 
-        min_sec = time_to_seconds(self.settings.minimum_length)
-        max_sec = time_to_seconds(self.settings.maximum_length)
-        fr = duration_filter(video_length, min_sec, max_sec)
-        if not fr.passed:
-            result.filter_result = fr
-            log.info(
-                "Filtered by duration: %s - %s (%ds)",
-                channel_title,
-                activity.title,
-                video_length,
-            )
-            return result
-
         route_result = evaluate_rules(
             activity,
             channel_title,
@@ -220,6 +219,13 @@ class PipelineOrchestrator:
             self.default_playlist_id,
             self.default_playlist_title,
         )
+        if route_result is None:
+            result.filter_result = FilterResult(
+                passed=False, reason="No matching rule", skipped_by="no_rule_match"
+            )
+            log.info("No rule matched: %s - %s", channel_title, activity.title)
+            return result
+
         result.route_result = route_result
 
         try:

--- a/src/ys2wl/core/pipeline_runner.py
+++ b/src/ys2wl/core/pipeline_runner.py
@@ -1,0 +1,185 @@
+from ys2wl.api.deps import require_youtube
+from ys2wl.core.pipeline import PipelineOrchestrator
+from ys2wl.models.youtube import Channel, Playlist, RoutingRule
+from ys2wl.db import repository as repo
+import logging
+import sqlite3
+
+log = logging.getLogger("ys2wl.core.pipeline_runner")
+
+
+async def execute_pipeline(state, trigger="manual"):
+    require_youtube(state)
+    run_id = repo.create_pipeline_run(state.db_con, trigger=trigger)
+    if run_id is None:
+        log.error("Failed to create pipeline run")
+        return None
+    try:
+        channel_data = repo.get_channel(state.db_con)
+        playlist_data = repo.get_playlist(state.db_con)
+        if not channel_data:
+            channels = state.youtube.get_channel_id()
+            if channels:
+                channel_data = {"id": channels[0].id, "title": channels[0].title}
+                repo.insert_channel(
+                    state.db_con, channel_data["id"], channel_data["title"]
+                )
+        channel_data = repo.get_channel(state.db_con)  # refetch in case inserted
+        if not channel_data:
+            log.error("No channel found or created, aborting pipeline run.")
+            repo.finish_pipeline_run(
+                state.db_con,
+                run_id,
+                {"status": "failed", "error_message": "No channel found."},
+            )
+            return None
+
+        if not playlist_data:
+            playlists = state.youtube.get_user_playlists(channel_data["id"])
+            if playlists:
+                playlist_data = {"id": playlists[0].id, "title": playlists[0].title}
+                repo.insert_playlist(
+                    state.db_con, playlist_data["id"], playlist_data["title"]
+                )
+        playlist_data = repo.get_playlist(state.db_con)  # refetch in case inserted
+        if not playlist_data:
+            log.error("No playlist found or created, aborting pipeline run.")
+            repo.finish_pipeline_run(
+                state.db_con,
+                run_id,
+                {"status": "failed", "error_message": "No playlist found."},
+            )
+            return None
+
+        channel = Channel(id=channel_data["id"], title=channel_data["title"])
+        playlist = Playlist(id=playlist_data["id"], title=playlist_data["title"])
+
+        ignore_subs = [
+            e["pattern"] for e in repo.get_ignore_entries(state.db_con, "subscription")
+        ]
+        ignore_vids = [
+            e["pattern"] for e in repo.get_ignore_entries(state.db_con, "video")
+        ]
+        ignore_words = [
+            e["pattern"] for e in repo.get_ignore_entries(state.db_con, "words")
+        ]
+
+        db_rules = repo.get_routing_rules(state.db_con)
+        routing_rules = [
+            RoutingRule(
+                id=r["id"],
+                name=r["name"],
+                priority=r["priority"],
+                field=r["field"],
+                operator=r["operator"],
+                pattern=r["pattern"],
+                destination_playlist_id=r["destination_playlist_id"],
+                destination_playlist_title=r.get("destination_playlist_title", ""),
+                enabled=bool(r["enabled"]),
+                minimum_length=r.get("minimum_length", "0s"),
+                maximum_length=r.get("maximum_length", "0s"),
+                catch_all=bool(r.get("catch_all", 0)),
+            )
+            for r in db_rules
+        ]
+
+        import asyncio
+
+        def _run_orchestrator():
+            tcon = sqlite3.connect(state.settings.database_file)
+            tcon.row_factory = sqlite3.Row
+            try:
+                orch = PipelineOrchestrator(
+                    settings=state.settings,
+                    youtube=state.youtube,
+                    db_con=tcon,
+                    channel=channel,
+                    playlist=playlist,
+                    ignore_subscriptions=ignore_subs,
+                    ignore_videos=ignore_vids,
+                    ignore_words=ignore_words,
+                    default_playlist_id=playlist.id,
+                    default_playlist_title=playlist.title,
+                    routing_rules=routing_rules,
+                )
+                return orch.run()
+            finally:
+                tcon.close()
+
+        summary = await asyncio.to_thread(_run_orchestrator)
+
+        # persist per-video decisions
+        decisions = []
+        for skip in summary.subscription_skips:
+            decisions.append(
+                {
+                    "video_id": None,
+                    "title": skip.get("subscription_title"),
+                    "subscription_title": skip.get("subscription_title"),
+                    "action": "subscription_skipped",
+                    "reason": skip.get("reason"),
+                    "reason_detail": skip.get("reason_detail"),
+                    "routed_to": None,
+                }
+            )
+        for r in summary.video_results:
+            if r.added:
+                action = "added"
+                reason = None
+                reason_detail = None
+            elif r.error:
+                action = "error"
+                reason = "add_failed"
+                reason_detail = r.error
+            elif r.filter_result:
+                action = "skipped"
+                reason = r.filter_result.skipped_by or "filter"
+                reason_detail = r.filter_result.reason
+            else:
+                action = "skipped"
+                reason = "unknown"
+                reason_detail = None
+            decisions.append(
+                {
+                    "video_id": r.video_id,
+                    "title": r.title,
+                    "subscription_title": r.subscription_title,
+                    "action": action,
+                    "reason": reason,
+                    "reason_detail": reason_detail,
+                    "routed_to": r.route_result.playlist_title
+                    if r.route_result
+                    else None,
+                }
+            )
+        if decisions:
+            repo.insert_run_decisions(state.db_con, run_id, decisions)
+        repo.cleanup_old_decisions(state.db_con)
+
+        repo.finish_pipeline_run(
+            state.db_con,
+            run_id,
+            {
+                "status": summary.status,
+                "videos_added": summary.videos_added,
+                "videos_skipped": summary.videos_skipped,
+                "subscriptions_processed": summary.subscriptions_processed,
+                "subscriptions_skipped": summary.subscriptions_skipped,
+                "errors": summary.errors,
+                "error_message": summary.error_message,
+            },
+        )
+
+        if summary.errors == 0:
+            repo.set_last_run(state.db_con, summary.started_at)
+
+    except Exception as e:
+        log.error("Pipeline run %d failed: %s", run_id, e)
+        repo.finish_pipeline_run(
+            state.db_con,
+            run_id,
+            {"status": "failed", "error_message": str(e)},
+        )
+        return None
+
+    return run_id

--- a/src/ys2wl/models/pipeline.py
+++ b/src/ys2wl/models/pipeline.py
@@ -41,3 +41,4 @@ class PipelineSummary:
     error_message: str = ""
     trigger: str = "scheduled"
     video_results: list[VideoResult] = field(default_factory=list)
+    subscription_skips: list[dict] = field(default_factory=list)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -40,3 +40,4 @@ def test_pipeline_summary_defaults():
     s = PipelineSummary(started_at="now")
     assert s.status == "running"
     assert s.videos_added == 0
+    assert s.subscription_skips == []

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -12,8 +12,6 @@ def settings():
     s = Settings()
     s.compare_distance = 80
     s.reprocess_days = 2
-    s.minimum_length = "0s"
-    s.maximum_length = "0s"
     s.playlist_sleep = 0
     s.subscription_sleep = 0
     s.subscription_limit = 0
@@ -55,6 +53,22 @@ def test_pipeline_run_no_subscriptions(settings, db_con):
     assert result.subscriptions_processed == 0
 
 
+def _catch_all_rule():
+    from ys2wl.models.youtube import RoutingRule
+
+    return RoutingRule(
+        name="Default Catch-all",
+        priority=0,
+        field=None,
+        operator="contains",
+        pattern=None,
+        destination_playlist_id="PL_DEFAULT",
+        destination_playlist_title="Default",
+        enabled=True,
+        catch_all=True,
+    )
+
+
 def test_pipeline_adds_video(settings, db_con):
     mock_youtube = MagicMock()
     mock_youtube.get_subscriptions.return_value = [
@@ -83,12 +97,84 @@ def test_pipeline_adds_video(settings, db_con):
         ignore_words=[],
         default_playlist_id="PL1",
         default_playlist_title="Watch Later",
+        routing_rules=[_catch_all_rule()],
     )
 
     result = orchestrator.run()
     assert result.status == "completed"
     assert result.videos_added == 1
     assert mock_youtube.add_to_playlist.called
+
+
+def test_pipeline_skips_ignored_subscription(settings, db_con):
+    mock_youtube = MagicMock()
+    mock_youtube.get_subscriptions.return_value = [
+        Subscription(id="UC1", title="Channel One", channel_id="UC1"),
+        Subscription(id="UC2", title="Boring Channel", channel_id="UC2"),
+    ]
+    mock_youtube.api_calls = [0]
+
+    orchestrator = PipelineOrchestrator(
+        settings=settings,
+        youtube=mock_youtube,
+        db_con=db_con,
+        channel=Channel(id="UC1", title="My Channel"),
+        playlist=Playlist(id="PL1", title="Watch Later"),
+        ignore_subscriptions=["Boring Channel"],
+        ignore_videos=[],
+        ignore_words=[],
+        default_playlist_id="PL1",
+        default_playlist_title="Watch Later",
+    )
+
+    result = orchestrator.run()
+    assert result.status == "completed"
+    assert result.subscriptions_processed == 1
+    assert result.subscriptions_skipped == 1
+    assert len(result.subscription_skips) == 1
+    assert result.subscription_skips[0]["subscription_title"] == "Boring Channel"
+    assert result.subscription_skips[0]["reason"] == "ignored"
+
+
+def test_pipeline_skips_reprocessed_subscription(settings, db_con):
+    from datetime import datetime, timezone, timedelta
+
+    db_con.execute(
+        "INSERT OR REPLACE INTO subscription (id, title, timestamp) VALUES (?, ?, ?)",
+        (
+            "UC1",
+            "Channel One",
+            (datetime.now(timezone.utc) - timedelta(days=1)).isoformat(),
+        ),
+    )
+    db_con.commit()
+
+    mock_youtube = MagicMock()
+    mock_youtube.get_subscriptions.return_value = [
+        Subscription(id="UC1", title="Channel One", channel_id="UC1"),
+    ]
+    mock_youtube.api_calls = [0]
+
+    orchestrator = PipelineOrchestrator(
+        settings=settings,
+        youtube=mock_youtube,
+        db_con=db_con,
+        channel=Channel(id="UC1", title="My Channel"),
+        playlist=Playlist(id="PL1", title="Watch Later"),
+        ignore_subscriptions=[],
+        ignore_videos=[],
+        ignore_words=[],
+        default_playlist_id="PL1",
+        default_playlist_title="Watch Later",
+    )
+
+    result = orchestrator.run()
+    assert result.status == "completed"
+    assert result.subscriptions_processed == 0
+    assert result.subscriptions_skipped == 1
+    assert len(result.subscription_skips) == 1
+    assert result.subscription_skips[0]["subscription_title"] == "Channel One"
+    assert result.subscription_skips[0]["reason"] == "already_up_to_date"
 
 
 def test_pipeline_word_filter_skips(settings, db_con):
@@ -117,6 +203,39 @@ def test_pipeline_word_filter_skips(settings, db_con):
         ignore_words=["sketchy"],
         default_playlist_id="PL1",
         default_playlist_title="Watch Later",
+    )
+
+    result = orchestrator.run()
+    assert result.status == "completed"
+    assert result.videos_added == 0
+    assert result.videos_skipped == 1
+
+
+def test_pipeline_no_rule_match_skips(settings, db_con):
+    mock_youtube = MagicMock()
+    mock_youtube.get_subscriptions.return_value = [
+        Subscription(id="UC1", title="Channel One", channel_id="UC1"),
+    ]
+    mock_youtube.get_subscription_activity.return_value = [
+        Activity(
+            video_id="v1", title="Any Video", published_at="now", video_type="upload"
+        ),
+    ]
+    mock_youtube.get_video_duration.return_value = 300
+    mock_youtube.api_calls = [0]
+
+    orchestrator = PipelineOrchestrator(
+        settings=settings,
+        youtube=mock_youtube,
+        db_con=db_con,
+        channel=Channel(id="UC1", title="My Channel"),
+        playlist=Playlist(id="PL1", title="Watch Later"),
+        ignore_subscriptions=[],
+        ignore_videos=[],
+        ignore_words=[],
+        default_playlist_id="PL1",
+        default_playlist_title="Watch Later",
+        routing_rules=[],  # No rules at all → no match
     )
 
     result = orchestrator.run()


### PR DESCRIPTION
Extracts pipeline execution into a dedicated module and tracks detailed per-video decisions for better visibility:
- New `PipelineRunner` async-compatible execution from `pipeline_runner.py`
- Subscription skip tracking (ignore list, already up-to-date)
- Per-video decision persistence with action/reason/routing info
- Run detail endpoint returning full decision history
- UI improvements: sub-skip section in run detail, runs table with added/skipped columns
- Old decisions cleanup