### PR TITLE
feat: show next scheduled pipeline run on dashboard

### DIFF
--- a/src/ys2wl/api/models.py
+++ b/src/ys2wl/api/models.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 class HealthResponse(BaseModel):
     status: str = "ok"
+    next_scheduled_run: str | None = None
 
 
 class ConfigResponse(BaseModel):

--- a/src/ys2wl/api/routes/health.py
+++ b/src/ys2wl/api/routes/health.py
@@ -1,9 +1,13 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from ys2wl.api.models import HealthResponse
 
 router = APIRouter()
 
 
 @router.get("/health", response_model=HealthResponse)
-async def health_check():
-    return HealthResponse()
+async def health_check(request: Request):
+    state = request.app.state.ys2wl
+    next_run = None
+    if state.scheduler:
+        next_run = state.scheduler.next_run_time
+    return HealthResponse(next_scheduled_run=next_run)

--- a/src/ys2wl/core/scheduler.py
+++ b/src/ys2wl/core/scheduler.py
@@ -27,6 +27,13 @@ class PipelineScheduler:
         )
         await self.pipeline_fn()
 
+    @property
+    def next_run_time(self) -> str | None:
+        job = self.scheduler.get_job("pipeline")
+        if job and job.next_run_time:
+            return job.next_run_time.isoformat()
+        return None
+
     def stop(self) -> None:
         if self.scheduler.running:
             self.scheduler.shutdown(wait=False)

--- a/ui/index.html
+++ b/ui/index.html
@@ -158,7 +158,7 @@ label { display: block; font-size: 0.875rem; color: var(--text2); margin-bottom:
 <div class="main">
   <div class="topbar">
     <span><span class="health-dot" id="healthDot"></span><span id="healthText">loading...</span></span>
-    <span id="lastRunText"></span>
+    <span id="nextRunText" style="font-size:0.75rem"></span>
   </div>
 
   <section id="dashboard" class="page active">
@@ -309,6 +309,21 @@ async function updateHealth() {
     const data = await api('/api/health');
     document.getElementById('healthDot').style.background = 'var(--success)';
     document.getElementById('healthText').textContent = 'healthy';
+    const nextEl = document.getElementById('nextRunText');
+    if (data.next_scheduled_run) {
+      const next = new Date(data.next_scheduled_run);
+      const now = new Date();
+      const diff = Math.max(0, Math.floor((next - now) / 1000));
+      const h = Math.floor(diff / 3600);
+      const m = Math.floor((diff % 3600) / 60);
+      const s = diff % 60;
+      const fmt = diff > 0
+        ? (h > 0 ? h+'h ' : '') + m+'m ' + s+'s'
+        : 'now';
+      nextEl.textContent = 'Next automatic run: ' + next.toLocaleString() + ' (' + fmt + ')';
+    } else {
+      nextEl.textContent = '';
+    }
   } catch {
     document.getElementById('healthDot').style.background = 'var(--error)';
     document.getElementById('healthText').textContent = 'unreachable';


### PR DESCRIPTION
Adds next scheduled run time to the dashboard topbar.

- scheduler.py: add `next_run_time` property exposing APScheduler job next trigger
- models.py: add `next_scheduled_run` field to HealthResponse
- health.py: inject scheduler next run (or None) into health endpoint
- index.html: display countdown in topbar, polled every 30s via existing health check