### PR TITLE
feat: add video/channel links in run decisions and video lookup UI

### DIFF
--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,32 @@
+## Summary
+
+Enhances the pipeline skip decision logging with detailed matched video information and adds a new API endpoint for video lookup.
+
+## Changes
+
+### Enhanced Skip Reasoning
+- **FilterResult model** (`src/ys2wl/models/pipeline.py`): Added `matched_video_id`, `matched_title`, `match_type` fields
+- **All filter functions** now populate match details:
+  - `video_exists_for_pipeline` returns full video details (title, timestamp, etc.)
+  - `title_similarity` includes matched video ID, title, and similarity %
+  - `ignore_list_filter` includes matched video ID
+  - `word_filter` includes matched title and word
+  - Duration checks (min/max) include video ID and title
+  - Selector filter includes video ID and title
+
+### Decision Logging
+- Pipeline run decisions now include structured `reason_detail` with:
+  - `matched_video_id=<id>`
+  - `matched_title='<title>'`
+  - `match_type=<exact|title_similarity|word|duration_min|duration_max|selector|ignore_list>`
+
+### New Video Lookup API
+- Added `GET /api/videos/{video_id}` endpoint
+- Returns video details across all pipelines for cross-referencing skipped videos
+
+### Database
+- Added `get_video_by_id` repository function
+- `video_exists_for_pipeline` now returns `(bool, Optional[dict])` tuple
+
+## Testing
+All 112 tests pass.

--- a/src/ys2wl/api/models.py
+++ b/src/ys2wl/api/models.py
@@ -166,7 +166,9 @@ class RunDecisionResponse(BaseModel):
     id: int
     video_id: Optional[str] = None
     title: Optional[str] = None
+    subscription_id: Optional[str] = None
     subscription_title: Optional[str] = None
+    channel_id: Optional[str] = None
     action: str
     reason: Optional[str] = None
     reason_detail: Optional[str] = None

--- a/src/ys2wl/api/routes/pipelines.py
+++ b/src/ys2wl/api/routes/pipelines.py
@@ -228,3 +228,25 @@ async def list_playlists(request: Request):
         raise HTTPException(status_code=404, detail="No channel found")
     playlists = youtube.get_user_playlists(channel_id)
     return [PlaylistResponse(id=p.id, title=p.title) for p in playlists]
+
+
+# ── Video Lookup ───────────────────────────────────────────────────────
+
+
+@router.get("/videos/{video_id}")
+async def get_video_by_id(video_id: str, request: Request):
+    """Look up video details by YouTube video ID across all pipelines."""
+    state = _get_state(request)
+    result = v.get_video_by_id(state.db_con, video_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="Video not found in database")
+    return {
+        "video_id": video_id,
+        "title": result.get("title"),
+        "timestamp": result.get("timestamp"),
+        "subscription_id": result.get("subscriptionId"),
+        "playlist_id": result.get("playlistId"),
+        "duration_seconds": result.get("duration_seconds"),
+        "route_rule": result.get("route_rule"),
+        "pipeline_id": result.get("pipeline_id"),
+    }

--- a/src/ys2wl/core/pipeline.py
+++ b/src/ys2wl/core/pipeline.py
@@ -183,7 +183,9 @@ class PipelineOrchestrator:
                 if sub.title in ignore_subs:
                     summary.subscriptions_skipped += 1
                     skip = dict(
+                        subscription_id=sub.id,
                         subscription_title=sub.title,
+                        channel_id=sub.channel_id,
                         reason="ignored",
                         reason_detail="Subscription in pipeline ignore list",
                     )
@@ -205,7 +207,9 @@ class PipelineOrchestrator:
                         if last_dt.replace(tzinfo=timezone.utc) > threshold:
                             summary.subscriptions_skipped += 1
                             skip = dict(
+                                subscription_id=sub.id,
                                 subscription_title=sub.title,
+                                channel_id=sub.channel_id,
                                 reason="already_up_to_date",
                                 reason_detail=f"Checked within {self.settings.reprocess_days}d reprocess window",
                             )

--- a/src/ys2wl/core/pipeline.py
+++ b/src/ys2wl/core/pipeline.py
@@ -337,11 +337,17 @@ class PipelineOrchestrator:
 
         # 2.3.4: Per-pipeline DB exists
         if pipeline.check_db_exists:
-            if v.video_exists_for_pipeline(self.db_con, activity.video_id, pipeline.id):
+            exists, existing_video = v.video_exists_for_pipeline(
+                self.db_con, activity.video_id, pipeline.id
+            )
+            if exists and existing_video:
                 result.filter_result = FilterResult(
                     passed=False,
-                    reason="Already in DB for this pipeline",
+                    reason=f"Video {activity.video_id} already exists in DB for this pipeline (matched: {existing_video.get('videoId', activity.video_id)}, title: '{existing_video.get('title', 'N/A')}')",
                     skipped_by="db_exists",
+                    matched_video_id=existing_video.get("videoId", activity.video_id),
+                    matched_title=existing_video.get("title", ""),
+                    match_type="exact",
                 )
                 return result
 
@@ -368,6 +374,9 @@ class PipelineOrchestrator:
                 passed=False,
                 reason=f"Duration {video_length}s below min {pipeline.duration_min_seconds}s",
                 skipped_by="duration",
+                matched_video_id=activity.video_id,
+                matched_title=activity.title,
+                match_type="duration_min",
             )
             return result
         if (
@@ -378,12 +387,18 @@ class PipelineOrchestrator:
                 passed=False,
                 reason=f"Duration {video_length}s above max {pipeline.duration_max_seconds}s",
                 skipped_by="duration",
+                matched_video_id=activity.video_id,
+                matched_title=activity.title,
+                match_type="duration_max",
             )
             return result
 
         # 2.3.7: Pipeline selectors
         fr = selector_filter(activity, sub.title, selectors, pipeline.selector_mode)
         if not fr.passed:
+            fr.matched_video_id = activity.video_id
+            fr.matched_title = activity.title
+            fr.match_type = "selector"
             result.filter_result = fr
             return result
 

--- a/src/ys2wl/core/pipeline_runner.py
+++ b/src/ys2wl/core/pipeline_runner.py
@@ -102,7 +102,9 @@ async def execute_pipeline(state, trigger="manual", dry_run=False, pipeline_id=N
                         d = {
                             "video_id": None,
                             "title": decision.get("subscription_title"),
+                            "subscription_id": decision.get("subscription_id"),
                             "subscription_title": decision.get("subscription_title"),
+                            "channel_id": decision.get("channel_id"),
                             "action": "subscription_skipped",
                             "reason": decision.get("reason"),
                             "reason_detail": decision.get("reason_detail"),
@@ -140,7 +142,10 @@ async def execute_pipeline(state, trigger="manual", dry_run=False, pipeline_id=N
                         d = {
                             "video_id": r.video_id,
                             "title": r.title,
+                            "subscription_id": r.subscription_id,
                             "subscription_title": r.subscription_title,
+                            "channel_id": getattr(r, "channel_id", None)
+                            or getattr(r, "_channel_id", None),
                             "action": action,
                             "reason": reason,
                             "reason_detail": reason_detail,

--- a/src/ys2wl/core/pipeline_runner.py
+++ b/src/ys2wl/core/pipeline_runner.py
@@ -121,7 +121,20 @@ async def execute_pipeline(state, trigger="manual", dry_run=False, pipeline_id=N
                         elif r.filter_result:
                             action = "skipped"
                             reason = r.filter_result.skipped_by or "filter"
-                            reason_detail = r.filter_result.reason
+                            # Build detailed reason_detail with matched video info
+                            fr = r.filter_result
+                            detail_parts = [fr.reason]
+                            if fr.matched_video_id:
+                                detail_parts.append(
+                                    f"matched_video_id={fr.matched_video_id}"
+                                )
+                            if fr.matched_title:
+                                detail_parts.append(
+                                    f"matched_title='{fr.matched_title}'"
+                                )
+                            if fr.match_type:
+                                detail_parts.append(f"match_type={fr.match_type}")
+                            reason_detail = " | ".join(detail_parts)
                         else:
                             action, reason, reason_detail = "skipped", "unknown", None
                         d = {

--- a/src/ys2wl/db/migrations.py
+++ b/src/ys2wl/db/migrations.py
@@ -68,7 +68,9 @@ CREATE TABLE IF NOT EXISTS pipeline_run_decisions (
     run_id INTEGER NOT NULL REFERENCES pipeline_runs(id),
     video_id TEXT,
     title TEXT,
+    subscription_id TEXT,
     subscription_title TEXT,
+    channel_id TEXT,
     action TEXT NOT NULL,
     reason TEXT,
     reason_detail TEXT,
@@ -209,6 +211,12 @@ def init_db(db_path: str) -> bool:
             con,
             "ALTER TABLE pipeline_selectors ADD COLUMN combine_operator TEXT NOT NULL DEFAULT 'AND'",
         )
+        # V5: add subscription_id and channel_id to pipeline_run_decisions
+        for stmt in [
+            "ALTER TABLE pipeline_run_decisions ADD COLUMN subscription_id TEXT",
+            "ALTER TABLE pipeline_run_decisions ADD COLUMN channel_id TEXT",
+        ]:
+            _run_migration_safe(con, stmt)
         # Migrate ignore_entries → ignore_lists if not done
         rows = con.execute("SELECT COUNT(*) as cnt FROM ignore_lists").fetchone()
         if rows["cnt"] == 0:

--- a/src/ys2wl/db/repository/pipeline_runs.py
+++ b/src/ys2wl/db/repository/pipeline_runs.py
@@ -120,13 +120,15 @@ def insert_run_decision(con: sqlite3.Connection, run_id: int, decision: dict) ->
     try:
         now = datetime.now(timezone.utc).isoformat()
         con.execute(
-            "INSERT INTO pipeline_run_decisions (run_id, video_id, title, subscription_title, action, reason, reason_detail, routed_to, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO pipeline_run_decisions (run_id, video_id, title, subscription_id, subscription_title, channel_id, action, reason, reason_detail, routed_to, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 run_id,
                 decision.get("video_id"),
                 decision.get("title"),
+                decision.get("subscription_id"),
                 decision.get("subscription_title"),
+                decision.get("channel_id"),
                 decision.get("action"),
                 decision.get("reason"),
                 decision.get("reason_detail"),

--- a/src/ys2wl/db/repository/videos.py
+++ b/src/ys2wl/db/repository/videos.py
@@ -22,6 +22,7 @@ __all__ = [
     "clear_activity_cache",
     "video_exists_for_pipeline",
     "get_all_video_titles_for_pipeline",
+    "get_video_by_id",
 ]
 
 
@@ -200,12 +201,16 @@ def clear_activity_cache(con: sqlite3.Connection) -> None:
 
 def video_exists_for_pipeline(
     con: sqlite3.Connection, video_id: str, pipeline_id: str
-) -> bool:
+) -> tuple[bool, Optional[dict]]:
+    """Check if video exists for pipeline. Returns (exists, video_details) where video_details has videoId, title, timestamp, etc."""
     cursor = con.execute(
-        "SELECT 1 FROM videos WHERE videoId = ? AND pipeline_id = ? LIMIT 1",
+        "SELECT videoId, title, timestamp, subscriptionId, playlistId, duration_seconds, route_rule, pipeline_id FROM videos WHERE videoId = ? AND pipeline_id = ? LIMIT 1",
         (video_id, pipeline_id),
     )
-    return cursor.fetchone() is not None
+    row = cursor.fetchone()
+    if row:
+        return True, dict(row)
+    return False, None
 
 
 def get_all_video_titles_for_pipeline(
@@ -215,3 +220,15 @@ def get_all_video_titles_for_pipeline(
         "SELECT videoId, title FROM videos WHERE pipeline_id = ?", (pipeline_id,)
     )
     return cursor.fetchall()
+
+
+def get_video_by_id(con: sqlite3.Connection, video_id: str) -> Optional[dict]:
+    """Get video details by video ID across all pipelines."""
+    cursor = con.execute(
+        "SELECT videoId, title, timestamp, subscriptionId, playlistId, duration_seconds, route_rule, pipeline_id FROM videos WHERE videoId = ?",
+        (video_id,),
+    )
+    row = cursor.fetchone()
+    if row:
+        return dict(row)
+    return None

--- a/src/ys2wl/filters/ignore_list.py
+++ b/src/ys2wl/filters/ignore_list.py
@@ -7,5 +7,7 @@ def ignore_list_filter(video_id: str, ignore_list: list[str]) -> FilterResult:
             passed=False,
             reason=f"Video {video_id} is in ignore list",
             skipped_by="ignore_list",
+            matched_video_id=video_id,
+            match_type="exact",
         )
     return FilterResult(passed=True)

--- a/src/ys2wl/filters/title_similarity.py
+++ b/src/ys2wl/filters/title_similarity.py
@@ -44,5 +44,8 @@ def title_similarity(
                 passed=False,
                 reason=f"Title '{new_title}' is {ratio}% similar to existing video '{video_id}' (threshold: {threshold}%)",
                 skipped_by="title_similarity",
+                matched_video_id=video_id,
+                matched_title=existing_title,
+                match_type="title_similarity",
             )
     return FilterResult(passed=True)

--- a/src/ys2wl/filters/word_filter.py
+++ b/src/ys2wl/filters/word_filter.py
@@ -15,5 +15,7 @@ def word_filter(title: str, ignore_words: list[str]) -> FilterResult:
                 passed=False,
                 reason=f"Title contains ignored word '{word}'",
                 skipped_by="word_filter",
+                matched_title=title,
+                match_type="word",
             )
     return FilterResult(passed=True)

--- a/src/ys2wl/models/pipeline.py
+++ b/src/ys2wl/models/pipeline.py
@@ -7,6 +7,9 @@ class FilterResult:
     passed: bool
     reason: str = ""
     skipped_by: str = ""
+    matched_video_id: str = ""
+    matched_title: str = ""
+    match_type: str = ""  # "exact", "title_similarity", etc.
 
 
 @dataclass

--- a/ui/index.html
+++ b/ui/index.html
@@ -175,6 +175,14 @@ label { display: block; font-size: 0.875rem; color: var(--text2); margin-bottom:
       <button id="dryRunBtn" style="background:var(--surface2);color:var(--text)">🧪 Dry Run</button>
     </div>
     <div id="triggerResult" style="margin-top:0.75rem"></div>
+
+    <hr style="border:none;border-top:1px solid var(--surface2);margin:1.5rem 0">
+    <h3 style="font-size:1rem;color:var(--text2);margin-bottom:0.75rem">Video Lookup</h3>
+    <div style="display:flex;gap:0.5rem;flex-wrap:wrap;margin-bottom:1rem">
+      <input id="videoSearchInput" type="text" placeholder="Enter YouTube video ID (e.g. dQw4w9WgXcQ)" style="flex:1;min-width:300px;padding:0.5rem;border-radius:var(--radius);border:1px solid var(--surface2);background:var(--bg);color:var(--text)">
+      <button id="videoSearchBtn" style="padding:0.5rem 1rem">Search</button>
+    </div>
+    <div id="videoSearchResult" style="display:none"></div>
   </section>
   <section id="subscriptions" class="page">
     <h2>Subscriptions</h2>
@@ -429,6 +437,61 @@ document.getElementById('dryRunBtn')?.addEventListener('click', async function()
   } finally {
     this.disabled = false; this.textContent = '🧪 Dry Run';
   }
+});
+
+// ---- Video Lookup ----
+document.getElementById('videoSearchBtn')?.addEventListener('click', async function() {
+  const input = document.getElementById('videoSearchInput');
+  const resultDiv = document.getElementById('videoSearchResult');
+  const videoId = input.value.trim();
+  if (!videoId) {
+    showToast('Enter a YouTube video ID', 'warning');
+    return;
+  }
+  this.disabled = true; this.textContent = 'Searching...';
+  resultDiv.style.display = 'none';
+  resultDiv.innerHTML = '';
+  try {
+    const data = await api('/api/videos/' + encodeURIComponent(videoId));
+    resultDiv.style.display = 'block';
+    resultDiv.innerHTML = `
+      <div class="card" style="margin-top:0.5rem">
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem">
+          <h4 style="margin:0;color:var(--accent)">${escapeHtml(data.title || 'Unknown')}</h4>
+          <code style="font-size:0.75rem;color:var(--text2)">${escapeHtml(data.video_id)}</code>
+        </div>
+        <table style="width:100%;font-size:0.8rem;border-collapse:collapse">
+          <tr><td style="color:var(--text2);padding:0.25rem 0">Pipeline</td><td style="text-align:right;font-family:monospace">${escapeHtml(data.pipeline_id || '—')}</td></tr>
+          <tr><td style="color:var(--text2);padding:0.25rem 0">Subscription</td><td style="text-align:right;font-family:monospace">${escapeHtml(data.subscription_id || '—')}</td></tr>
+          <tr><td style="color:var(--text2);padding:0.25rem 0">Playlist</td><td style="text-align:right;font-family:monospace">${escapeHtml(data.playlist_id || '—')}</td></tr>
+          <tr><td style="color:var(--text2);padding:0.25rem 0">Duration</td><td style="text-align:right">${data.duration_seconds ? Math.floor(data.duration_seconds/60)+'m '+(data.duration_seconds%60)+'s' : '—'}</td></tr>
+          <tr><td style="color:var(--text2);padding:0.25rem 0">Added</td><td style="text-align:right;font-family:monospace;font-size:0.7rem">${escapeHtml(data.timestamp || '—')}</td></tr>
+          <tr><td style="color:var(--text2);padding:0.25rem 0">Route Rule</td><td style="text-align:right;font-family:monospace;font-size:0.7rem">${escapeHtml(data.route_rule || '—')}</td></tr>
+        </table>
+        <p style="margin-top:0.5rem;color:var(--success);font-size:0.8rem">✓ Found in database</p>
+      </div>
+    `;
+    showToast('Video found', 'success');
+  } catch (e) {
+    if (e.status === 404 || e.message?.includes('404')) {
+      resultDiv.style.display = 'block';
+      resultDiv.innerHTML = `
+        <div class="card" style="margin-top:0.5rem;border:1px solid var(--error)">
+          <p style="color:var(--error);margin:0">Video <code>${escapeHtml(videoId)}</code> not found in database</p>
+        </div>
+      `;
+      showToast('Video not found', 'warning');
+    } else {
+      showToast('Error: ' + e.message, 'error');
+    }
+  } finally {
+    this.disabled = false; this.textContent = 'Search';
+  }
+});
+
+// Allow Enter key in input
+document.getElementById('videoSearchInput')?.addEventListener('keydown', function(e) {
+  if (e.key === 'Enter') document.getElementById('videoSearchBtn').click();
 });
 
 // ---- Subscriptions renderer ----
@@ -950,13 +1013,13 @@ renderers.runDetail = async function(runId) {
         videoDecisions.forEach(d => { if (d.action === 'added') counts.added++; else if (d.action === 'error') counts.error++; else counts.skipped++; });
         let html = '';
         if (subSkips.length) {
-          html += `<div style="margin-bottom:1rem"><h4>Subscription Skips</h4>${subSkips.map(s => `<div style="padding:0.25rem 0;border-bottom:1px solid var(--border)"><strong>${escapeHtml(s.title)}</strong> &mdash; ${escapeHtml(s.reason_detail || s.reason)}</div>`).join('')}</div>`;
+          html += `<div style="margin-bottom:1rem"><h4>Subscription Skips</h4>${subSkips.map(s => `<div style="padding:0.25rem 0;border-bottom:1px solid var(--border)"><strong><a href="https://www.youtube.com/channel/${escapeHtml(s.channel_id || s.subscription_id || '')}" target="_blank" rel="noopener" style="color:var(--accent)">${escapeHtml(s.title)}</a></strong> &mdash; ${escapeHtml(s.reason_detail || s.reason)}</div>`).join('')}</div>`;
         }
         html += `<table><thead><tr>
           <th>Video</th><th>Channel</th><th>Action</th><th>Reason</th><th>Routed To</th>
         </tr></thead><tbody>${videoDecisions.map(d => `<tr>
-          <td style="max-width:250px;overflow:hidden;text-overflow:ellipsis">${escapeHtml(d.title)}</td>
-          <td>${escapeHtml(d.subscription_title)}</td>
+          <td style="max-width:250px;overflow:hidden;text-overflow:ellipsis"><a href="https://www.youtube.com/watch?v=${escapeHtml(d.video_id || '')}" target="_blank" rel="noopener" style="color:var(--accent)">${escapeHtml(d.title)}</a></td>
+          <td><a href="https://www.youtube.com/channel/${escapeHtml(d.channel_id || d.subscription_id || '')}" target="_blank" rel="noopener" style="color:var(--accent)">${escapeHtml(d.subscription_title)}</a></td>
           <td><span class="badge ${d.action === 'added' ? 'badge-ok' : d.action === 'error' ? 'badge-fail' : 'badge-run'}">${d.action}</span></td>
           <td style="max-width:300px;overflow:hidden;text-overflow:ellipsis">${escapeHtml(d.reason_detail || d.reason || '-')}</td>
           <td>${escapeHtml(d.routed_to || '-')}</td>


### PR DESCRIPTION
## Summary

Adds clickable YouTube links in pipeline run decisions and a Video Lookup UI on the Dashboard.

## Changes

### Backend
- **Database migration V5**: Added `subscription_id` and `channel_id` columns to `pipeline_run_decisions` table
- **Pipeline runner**: Records these IDs for both video decisions and subscription skips
- **API model**: `RunDecisionResponse` now includes `subscription_id` and `channel_id`

### Frontend
- **Run Detail page**: 
  - Video titles → `https://www.youtube.com/watch?v={video_id}`
  - Channel titles → `https://www.youtube.com/channel/{channel_id}` (falls back to subscription_id)
  - Subscription skips → channel names link to YouTube channel
- **Dashboard**: New "Video Lookup" section with search input hitting `/api/videos/{video_id}`

### Testing
- All 112 tests pass
- Migration verified against fresh and existing databases