### PR TITLE
feat: playlist video tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ __pycache__
 docs/superpowers/
 .opencode/
 graphify-out
+.worktrees

--- a/src/sortarr/api/app.py
+++ b/src/sortarr/api/app.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
@@ -12,6 +13,7 @@ from sortarr.core.youtube import YouTubeAPIClient
 from sortarr.core.auth import load_credentials
 from sortarr.core.scheduler import PipelineScheduler
 from sortarr.core.pipeline_runner import execute_pipeline
+from sortarr.core.playlist_tracker import PlaylistTracker
 from sortarr.db.migrations import init_db
 from sortarr.db.repository import config as repo
 from sortarr.api.routes import (
@@ -20,6 +22,7 @@ from sortarr.api.routes import (
     rules,
     pipeline as pipeline_routes,
     pipelines as pipelines_routes,
+    playlist_tracker as playlist_tracker_routes,
     subscriptions,
     stats as stats_routes,
 )
@@ -74,6 +77,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator:
     # Overlay DB config onto settings (DB wins)
     for key in [
         "schedule",
+        "playlist_tracker_schedule",
         "compare_distance",
         "credentials_file",
         "reprocess_days",
@@ -106,6 +110,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator:
 
     # --- SCHEDULER WIRING ---
     # Only start scheduler if a cron is set and credentials are valid
+    playlist_tracker_cron = getattr(state.settings, "playlist_tracker_schedule", None)
+
     if (
         getattr(state.settings, "schedule", None)
         and state.youtube is not None
@@ -116,7 +122,47 @@ async def lifespan(app: FastAPI) -> AsyncIterator:
         async def pipeline_callback():
             await execute_pipeline(state, trigger="auto")
 
-        state.scheduler = PipelineScheduler(state.settings.schedule, pipeline_callback)
+        async def playlist_tracker_callback():
+            channel = state.db_con.execute("SELECT id FROM channel LIMIT 1").fetchone()
+            cid = channel["id"] if channel else None
+            if not cid:
+                channels = state.youtube.get_channel_id()
+                if channels:
+                    cid = channels[0].id
+            if not cid:
+                log.warning("Cannot run playlist tracker — no channel ID")
+                return
+            import sqlite3
+
+            def _run():
+                tcon = sqlite3.connect(state.settings.database_file)
+                tcon.row_factory = sqlite3.Row
+                client = YouTubeAPIClient(credentials=state.credentials)
+                try:
+                    tracker = PlaylistTracker(client, tcon, cid)
+                    result = tracker.run()
+                    log.info("Playlist tracker result: %s", result)
+                    return result
+                finally:
+                    client.close()
+                    tcon.close()
+
+            await asyncio.to_thread(_run)
+
+        state.scheduler = PipelineScheduler(
+            state.settings.schedule,
+            pipeline_callback,
+            playlist_tracker_cron=(
+                playlist_tracker_cron
+                if playlist_tracker_cron and playlist_tracker_cron.strip() != ""
+                else None
+            ),
+            playlist_tracker_fn=(
+                playlist_tracker_callback
+                if playlist_tracker_cron and playlist_tracker_cron.strip() != ""
+                else None
+            ),
+        )
         state.scheduler.start()
         log.info(f"PipelineScheduler started with cron: {state.settings.schedule}")
     else:
@@ -151,6 +197,11 @@ def create_app() -> FastAPI:
     app.include_router(subscriptions.router, prefix="/api", tags=["subscriptions"])
     app.include_router(stats_routes.router, prefix="/api", tags=["stats"])
     app.include_router(auth_routes.router, prefix="/api", tags=["auth"])
+    app.include_router(
+        playlist_tracker_routes.router,
+        prefix="/api",
+        tags=["playlist-tracker"],
+    )
 
     metrics_app = make_asgi_app()
     app.mount("/metrics", metrics_app)

--- a/src/sortarr/api/models.py
+++ b/src/sortarr/api/models.py
@@ -206,6 +206,7 @@ class SubscriptionStat(BaseModel):
     videos_added: int = 0
     last_added_at: Optional[str] = None
     status: str = "inactive"
+    added_to_playlist_count: int = 0
 
 
 class PlaylistResponse(BaseModel):

--- a/src/sortarr/api/routes/pipelines.py
+++ b/src/sortarr/api/routes/pipelines.py
@@ -12,7 +12,12 @@ from sortarr.api.models import (
     PlaylistResponse,
 )
 from sortarr.api.deps import get_state, require_youtube
-from sortarr.db.repository import pipeline as pl, ignore_lists as il, videos as v
+from sortarr.db.repository import (
+    pipeline as pl,
+    ignore_lists as il,
+    videos as v,
+    pipeline_runs as pr,
+)
 
 log = logging.getLogger("sortarr.api.pipelines")
 router = APIRouter()
@@ -249,4 +254,29 @@ async def get_video_by_id(video_id: str, request: Request):
         "duration_seconds": result.get("duration_seconds"),
         "route_rule": result.get("route_rule"),
         "pipeline_id": result.get("pipeline_id"),
+    }
+
+
+@router.get("/videos/{video_id}/runs")
+async def get_video_runs(video_id: str, request: Request):
+    """Get pipeline runs where a specific video appeared."""
+    state = _get_state(request)
+    runs = pr.get_runs_by_video_id(state.db_con, video_id, limit=50)
+    return {
+        "video_id": video_id,
+        "runs": [
+            {
+                "run_id": r.get("id"),
+                "started_at": r.get("started_at"),
+                "finished_at": r.get("finished_at"),
+                "status": r.get("status"),
+                "trigger": r.get("trigger"),
+                "videos_added": r.get("videos_added"),
+                "videos_skipped": r.get("videos_skipped"),
+                "errors": r.get("errors"),
+                "dry_run": bool(r.get("dry_run")),
+            }
+            for r in runs
+        ],
+        "total": len(runs),
     }

--- a/src/sortarr/api/routes/playlist_tracker.py
+++ b/src/sortarr/api/routes/playlist_tracker.py
@@ -1,0 +1,40 @@
+import logging
+from fastapi import APIRouter, HTTPException, Request
+from sortarr.api.deps import get_state, require_youtube
+from sortarr.core.playlist_tracker import PlaylistTracker
+from sortarr.core.youtube import YouTubeAPIClient
+
+log = logging.getLogger("sortarr.api.playlist_tracker")
+router = APIRouter()
+
+
+@router.post("/playlist-tracker/trigger")
+async def trigger_playlist_tracker(request: Request):
+    state = get_state(request)
+    youtube = require_youtube(state)
+
+    channel = state.db_con.execute("SELECT id FROM channel LIMIT 1").fetchone()
+    channel_id = channel["id"] if channel else None
+    if not channel_id:
+        channels = youtube.get_channel_id()
+        if channels:
+            channel_id = channels[0].id
+    if not channel_id:
+        raise HTTPException(status_code=404, detail="No channel found")
+
+    import asyncio
+    import sqlite3
+
+    def _run():
+        tcon = sqlite3.connect(state.settings.database_file)
+        tcon.row_factory = sqlite3.Row
+        client = YouTubeAPIClient(credentials=state.credentials)
+        try:
+            tracker = PlaylistTracker(client, tcon, channel_id)
+            return tracker.run()
+        finally:
+            client.close()
+            tcon.close()
+
+    result = await asyncio.to_thread(_run)
+    return result

--- a/src/sortarr/api/routes/stats.py
+++ b/src/sortarr/api/routes/stats.py
@@ -23,7 +23,8 @@ async def get_subscription_stats(request: Request):
             SELECT v.subscriptionId,
                    COALESCE(s.title, v.subscriptionId) AS title,
                    COUNT(v.videoId) AS videos_added,
-                   MAX(v.timestamp) AS last_added_at
+                   MAX(v.timestamp) AS last_added_at,
+                   COALESCE(s.added_to_playlist_count, 0) AS added_to_playlist_count
             FROM videos v
             LEFT JOIN subscription s ON v.subscriptionId = s.id
             GROUP BY v.subscriptionId
@@ -66,6 +67,7 @@ async def get_subscription_stats(request: Request):
                 videos_added=row[2] or 0,
                 last_added_at=row[3],
                 status=status,
+                added_to_playlist_count=row[4] or 0,
             )
         )
     return result

--- a/src/sortarr/api/routes/subscriptions.py
+++ b/src/sortarr/api/routes/subscriptions.py
@@ -12,6 +12,7 @@ class SubscriptionResponse(BaseModel):
     id: str
     title: str
     channel_id: str
+    added_to_playlist_count: int = 0
 
 
 class ActivityResponse(BaseModel):
@@ -19,6 +20,15 @@ class ActivityResponse(BaseModel):
     title: str
     published_at: str
     video_type: str
+
+
+def _get_added_count(con, sub_id: str) -> int:
+    row = con.execute(
+        "SELECT added_to_playlist_count FROM subscription WHERE id = ?", (sub_id,)
+    ).fetchone()
+    return (
+        row["added_to_playlist_count"] if row and row["added_to_playlist_count"] else 0
+    )
 
 
 @router.get("/subscriptions", response_model=List[SubscriptionResponse])
@@ -31,7 +41,12 @@ async def list_subscriptions(request: Request):
         log.error("Failed to list subscriptions: %s", e)
         raise HTTPException(status_code=502, detail=str(e))
     return [
-        SubscriptionResponse(id=s.id, title=s.title, channel_id=s.channel_id)
+        SubscriptionResponse(
+            id=s.id,
+            title=s.title,
+            channel_id=s.channel_id,
+            added_to_playlist_count=_get_added_count(state.db_con, s.id),
+        )
         for s in subs
     ]
 

--- a/src/sortarr/config.py
+++ b/src/sortarr/config.py
@@ -31,6 +31,7 @@ class Settings(BaseSettings):
     published_after: Optional[str] = Field(default=None)
     no_webbrowser: bool = Field(default=False)
     public_url: str = Field(default="http://localhost:8080")
+    playlist_tracker_schedule: str = Field(default="0 3 * * *")
 
 
 def load_settings() -> Settings:

--- a/src/sortarr/core/playlist_tracker.py
+++ b/src/sortarr/core/playlist_tracker.py
@@ -1,0 +1,180 @@
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+log = logging.getLogger("sortarr.playlist_tracker")
+
+
+class PlaylistTracker:
+    def __init__(self, youtube_client: Any, db_con: Any, channel_id: str):
+        self.youtube = youtube_client
+        self.db_con = db_con
+        self.channel_id = channel_id
+
+    def _get_playlists(self) -> list[dict]:
+        pipeline_ids = set()
+        rows = self.db_con.execute(
+            "SELECT destination_playlist_id FROM pipelines"
+        ).fetchall()
+        for row in rows:
+            pipeline_ids.add(row["destination_playlist_id"])
+
+        playlists = self.youtube.get_user_playlists(self.channel_id)
+        excluded = 0
+        result = []
+        for p in playlists:
+            if p.id in pipeline_ids:
+                excluded += 1
+                continue
+            title_lower = p.title.lower()
+            if "liked videos" in title_lower or "watch later" in title_lower:
+                excluded += 1
+                continue
+            result.append({"id": p.id, "title": p.title})
+        log.info("Found %d playlists (%d excluded)", len(result), excluded)
+        return result
+
+    def _get_playlist_items(self, playlist_id: str) -> list[dict]:
+        items = self.youtube.get_playlist(playlist_id)
+        result = []
+        for item in items:
+            snippet = item.get("snippet", {})
+            resource_id = snippet.get("resourceId", {})
+            video_id = resource_id.get("videoId", "")
+            if not video_id:
+                continue
+            result.append(
+                {
+                    "video_id": video_id,
+                    "channel_id": snippet.get("videoOwnerChannelId", ""),
+                    "title": snippet.get("title", ""),
+                    "published_at": snippet.get("publishedAt", ""),
+                }
+            )
+        return result
+
+    def _increment_count(
+        self, video_subscription_id: str, video_id: str, source_playlist_id: str
+    ) -> None:
+        self.db_con.execute(
+            "UPDATE playlist_video_tracking SET counted = 1 WHERE video_id = ? AND source_playlist_id = ?",
+            (video_id, source_playlist_id),
+        )
+        self.db_con.execute(
+            "UPDATE subscription SET added_to_playlist_count = COALESCE(added_to_playlist_count, 0) + 1 WHERE id = ?",
+            (video_subscription_id,),
+        )
+        self.db_con.commit()
+
+    def _process_video(
+        self, video_id: str, channel_id: str, source_playlist_id: str
+    ) -> bool:
+        now = datetime.now(timezone.utc).isoformat()
+
+        existing = self.db_con.execute(
+            "SELECT counted FROM playlist_video_tracking WHERE video_id = ? AND source_playlist_id = ?",
+            (video_id, source_playlist_id),
+        ).fetchone()
+
+        if existing:
+            if existing["counted"] == 1:
+                log.info(
+                    "Video %s already counted for playlist %s",
+                    video_id,
+                    source_playlist_id,
+                )
+                return False
+            video = self.db_con.execute(
+                "SELECT subscriptionId FROM videos WHERE videoId = ? LIMIT 1",
+                (video_id,),
+            ).fetchone()
+            if video:
+                self._increment_count(
+                    video["subscriptionId"], video_id, source_playlist_id
+                )
+                log.info(
+                    "Upgraded video %s to counted=1 for playlist %s",
+                    video_id,
+                    source_playlist_id,
+                )
+                return True
+            return False
+
+        video = self.db_con.execute(
+            "SELECT subscriptionId FROM videos WHERE videoId = ? LIMIT 1",
+            (video_id,),
+        ).fetchone()
+
+        if video:
+            self.db_con.execute(
+                "INSERT INTO playlist_video_tracking (video_id, source_playlist_id, counted, created_at) VALUES (?, ?, 1, ?)",
+                (video_id, source_playlist_id, now),
+            )
+            self._increment_count(video["subscriptionId"], video_id, source_playlist_id)
+            log.info(
+                "Video %s newly counted for playlist %s", video_id, source_playlist_id
+            )
+            return True
+        else:
+            self.db_con.execute(
+                "INSERT INTO playlist_video_tracking (video_id, source_playlist_id, counted, created_at) VALUES (?, ?, 0, ?)",
+                (video_id, source_playlist_id, now),
+            )
+            self.db_con.commit()
+            log.info(
+                "Video %s not in videos table, tracked as uncounted for playlist %s",
+                video_id,
+                source_playlist_id,
+            )
+            return False
+
+    def run(self) -> dict:
+        log.info("Starting playlist tracking run for channel %s", self.channel_id)
+        playlists_count = 0
+        videos_found = 0
+        videos_newly_counted = 0
+        subscriptions_set = set()
+
+        try:
+            playlists = self._get_playlists()
+        except Exception as e:
+            log.warning("Failed to get playlists: %s", e)
+            return {
+                "playlists_processed": 0,
+                "videos_found": 0,
+                "videos_newly_counted": 0,
+                "subscriptions_updated": 0,
+            }
+
+        for pl in playlists:
+            playlists_count += 1
+            try:
+                items = self._get_playlist_items(pl["id"])
+            except Exception as e:
+                log.warning("Failed to get items for playlist %s: %s", pl["id"], e)
+                continue
+            for item in items:
+                videos_found += 1
+                try:
+                    if self._process_video(
+                        item["video_id"], item["channel_id"], pl["id"]
+                    ):
+                        videos_newly_counted += 1
+                        if item["channel_id"]:
+                            subscriptions_set.add(item["channel_id"])
+                except Exception as e:
+                    log.warning(
+                        "Failed to process video %s in playlist %s: %s",
+                        item["video_id"],
+                        pl["id"],
+                        e,
+                    )
+
+        summary = {
+            "playlists_processed": playlists_count,
+            "videos_found": videos_found,
+            "videos_newly_counted": videos_newly_counted,
+            "subscriptions_updated": len(subscriptions_set),
+        }
+        log.info("Playlist tracking run complete: %s", summary)
+        return summary

--- a/src/sortarr/core/playlist_tracker.py
+++ b/src/sortarr/core/playlist_tracker.py
@@ -66,9 +66,7 @@ class PlaylistTracker:
         )
         self.db_con.commit()
 
-    def _process_video(
-        self, video_id: str, channel_id: str, source_playlist_id: str
-    ) -> bool:
+    def _process_video(self, video_id: str, source_playlist_id: str) -> bool:
         now = datetime.now(timezone.utc).isoformat()
 
         existing = self.db_con.execute(
@@ -107,7 +105,7 @@ class PlaylistTracker:
 
         if video:
             self.db_con.execute(
-                "INSERT INTO playlist_video_tracking (video_id, source_playlist_id, counted, created_at) VALUES (?, ?, 1, ?)",
+                "INSERT OR IGNORE INTO playlist_video_tracking (video_id, source_playlist_id, counted, created_at) VALUES (?, ?, 1, ?)",
                 (video_id, source_playlist_id, now),
             )
             self._increment_count(video["subscriptionId"], video_id, source_playlist_id)
@@ -117,7 +115,7 @@ class PlaylistTracker:
             return True
         else:
             self.db_con.execute(
-                "INSERT INTO playlist_video_tracking (video_id, source_playlist_id, counted, created_at) VALUES (?, ?, 0, ?)",
+                "INSERT OR IGNORE INTO playlist_video_tracking (video_id, source_playlist_id, counted, created_at) VALUES (?, ?, 0, ?)",
                 (video_id, source_playlist_id, now),
             )
             self.db_con.commit()
@@ -156,9 +154,7 @@ class PlaylistTracker:
             for item in items:
                 videos_found += 1
                 try:
-                    if self._process_video(
-                        item["video_id"], item["channel_id"], pl["id"]
-                    ):
+                    if self._process_video(item["video_id"], pl["id"]):
                         videos_newly_counted += 1
                         if item["channel_id"]:
                             subscriptions_set.add(item["channel_id"])

--- a/src/sortarr/core/scheduler.py
+++ b/src/sortarr/core/scheduler.py
@@ -8,9 +8,17 @@ log = logging.getLogger("sortarr.scheduler")
 
 
 class PipelineScheduler:
-    def __init__(self, cron_expression: str, pipeline_fn: Callable):
+    def __init__(
+        self,
+        cron_expression: str,
+        pipeline_fn: Callable,
+        playlist_tracker_cron: str | None = None,
+        playlist_tracker_fn: Callable | None = None,
+    ):
         self.cron_expression = cron_expression
         self.pipeline_fn = pipeline_fn
+        self.playlist_tracker_cron = playlist_tracker_cron
+        self.playlist_tracker_fn = playlist_tracker_fn
         self.scheduler = AsyncIOScheduler()
 
     def start(self) -> None:
@@ -18,8 +26,21 @@ class PipelineScheduler:
         self.scheduler.add_job(
             self.pipeline_fn, trigger, id="pipeline", name="YouTube Pipeline"
         )
+        if self.playlist_tracker_cron and self.playlist_tracker_fn:
+            pt_trigger = CronTrigger.from_crontab(self.playlist_tracker_cron)
+            self.scheduler.add_job(
+                self.playlist_tracker_fn,
+                pt_trigger,
+                id="playlist_tracker",
+                name="Playlist Video Tracker",
+            )
         self.scheduler.start()
         log.info("Scheduler started with cron: %s", self.cron_expression)
+        if self.playlist_tracker_cron:
+            log.info(
+                "Playlist tracker scheduled with cron: %s",
+                self.playlist_tracker_cron,
+            )
 
     async def run_once(self) -> None:
         log.info(
@@ -27,12 +48,27 @@ class PipelineScheduler:
         )
         await self.pipeline_fn()
 
+    async def run_playlist_tracker_once(self) -> None:
+        if self.playlist_tracker_fn:
+            log.info(
+                "Manual playlist tracker trigger at %s",
+                datetime.now(timezone.utc).isoformat(),
+            )
+            await self.playlist_tracker_fn()
+
     @property
     def next_run_time(self) -> str | None:
-        job = self.scheduler.get_job("pipeline")
-        if job and job.next_run_time:
-            return job.next_run_time.isoformat()
-        return None
+        pipeline_job = self.scheduler.get_job("pipeline")
+        tracker_job = self.scheduler.get_job("playlist_tracker")
+        times = []
+        if pipeline_job and pipeline_job.next_run_time:
+            times.append(pipeline_job.next_run_time)
+        if tracker_job and tracker_job.next_run_time:
+            times.append(tracker_job.next_run_time)
+        if not times:
+            return None
+        earliest = min(times)
+        return earliest.isoformat()
 
     def stop(self) -> None:
         if self.scheduler.running:

--- a/src/sortarr/db/migrations.py
+++ b/src/sortarr/db/migrations.py
@@ -225,6 +225,21 @@ def init_db(db_path: str) -> bool:
         rows = con.execute("SELECT COUNT(*) as cnt FROM pipelines").fetchone()
         if rows["cnt"] == 0:
             _migrate_v1_rules(con)
+        # V6: playlist video tracking
+        con.executescript("""
+CREATE TABLE IF NOT EXISTS playlist_video_tracking (
+    video_id TEXT NOT NULL,
+    source_playlist_id TEXT NOT NULL,
+    counted INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (video_id, source_playlist_id)
+);
+""")
+        # V7: added_to_playlist_count on subscription
+        _run_migration_safe(
+            con,
+            "ALTER TABLE subscription ADD COLUMN added_to_playlist_count INTEGER NOT NULL DEFAULT 0",
+        )
         con.commit()
         con.close()
         return True

--- a/src/sortarr/db/repository/pipeline_runs.py
+++ b/src/sortarr/db/repository/pipeline_runs.py
@@ -15,6 +15,7 @@ __all__ = [
     "insert_run_decision",
     "update_pipeline_run_progress",
     "cleanup_old_decisions",
+    "get_runs_by_video_id",
 ]
 
 
@@ -183,3 +184,23 @@ def cleanup_old_decisions(con: sqlite3.Connection, days: int = 10) -> bool:
     except sqlite3.Error as err:
         log.error("Failed to cleanup old decisions: %s", err)
         return False
+
+
+def get_runs_by_video_id(
+    con: sqlite3.Connection, video_id: str, limit: int = 50
+) -> list[dict]:
+    """Get pipeline runs where a specific video appeared."""
+    cursor = con.execute(
+        """
+        SELECT DISTINCT pr.id, pr.started_at, pr.finished_at, pr.status, pr.trigger,
+               pr.subscriptions_processed, pr.subscriptions_skipped, pr.videos_added,
+               pr.videos_skipped, pr.errors, pr.dry_run
+        FROM pipeline_runs pr
+        JOIN pipeline_run_decisions prd ON pr.id = prd.run_id
+        WHERE prd.video_id = ?
+        ORDER BY pr.id DESC
+        LIMIT ?
+        """,
+        (video_id, limit),
+    )
+    return [dict(row) for row in cursor.fetchall()]

--- a/tests/test_playlist_tracker.py
+++ b/tests/test_playlist_tracker.py
@@ -28,7 +28,7 @@ def test_process_video_new_match():
         None,
     ]
     tracker = PlaylistTracker(youtube, db, channel_id="UC123")
-    result = tracker._process_video("vid1", "UC123", "PL99")
+    result = tracker._process_video("vid1", "PL99")
     assert result is True
 
 
@@ -37,7 +37,7 @@ def test_process_video_already_counted():
     db = Mock()
     db.execute.return_value.fetchone.return_value = {"counted": 1}
     tracker = PlaylistTracker(youtube, db, channel_id="UC123")
-    result = tracker._process_video("vid1", "UC123", "PL99")
+    result = tracker._process_video("vid1", "PL99")
     assert result is False
 
 
@@ -50,7 +50,7 @@ def test_process_video_not_in_videos_table():
         None,
     ]
     tracker = PlaylistTracker(youtube, db, channel_id="UC123")
-    result = tracker._process_video("vid1", "UC123", "PL99")
+    result = tracker._process_video("vid1", "PL99")
     assert result is False
 
 
@@ -98,7 +98,7 @@ def test_upgrade_from_counted_0_to_1():
     ]
 
     tracker = PlaylistTracker(youtube, db, channel_id="UC123")
-    result1 = tracker._process_video("vid1", "UC123", "PL99")
+    result1 = tracker._process_video("vid1", "PL99")
     assert result1 is False
 
     db.execute.return_value.fetchone.side_effect = [
@@ -106,5 +106,5 @@ def test_upgrade_from_counted_0_to_1():
         {"subscriptionId": "sub123"},
     ]
 
-    result2 = tracker._process_video("vid1", "UC123", "PL99")
+    result2 = tracker._process_video("vid1", "PL99")
     assert result2 is True

--- a/tests/test_playlist_tracker.py
+++ b/tests/test_playlist_tracker.py
@@ -1,0 +1,110 @@
+from unittest.mock import Mock, MagicMock
+from sortarr.core.playlist_tracker import PlaylistTracker
+
+
+def test_exclude_pipeline_playlists():
+    youtube = Mock()
+    youtube.get_user_playlists.return_value = [
+        type("Playlist", (), {"id": "PL1", "title": "Pipeline Dest"}),
+        type("Playlist", (), {"id": "PL2", "title": "Custom List"}),
+    ]
+    db = Mock()
+    db.execute.return_value.fetchall.return_value = [{"destination_playlist_id": "PL1"}]
+
+    tracker = PlaylistTracker(youtube, db, channel_id="UC123")
+    playlists = tracker._get_playlists()
+    assert len(playlists) == 1
+    assert playlists[0]["id"] == "PL2"
+
+
+def test_process_video_new_match():
+    youtube = Mock()
+    db = Mock()
+    db.execute.side_effect = [
+        Mock(fetchone=Mock(return_value=None)),
+        Mock(fetchone=Mock(return_value={"subscriptionId": "UC123"})),
+        None,
+        None,
+        None,
+    ]
+    tracker = PlaylistTracker(youtube, db, channel_id="UC123")
+    result = tracker._process_video("vid1", "UC123", "PL99")
+    assert result is True
+
+
+def test_process_video_already_counted():
+    youtube = Mock()
+    db = Mock()
+    db.execute.return_value.fetchone.return_value = {"counted": 1}
+    tracker = PlaylistTracker(youtube, db, channel_id="UC123")
+    result = tracker._process_video("vid1", "UC123", "PL99")
+    assert result is False
+
+
+def test_process_video_not_in_videos_table():
+    youtube = Mock()
+    db = Mock()
+    db.execute.side_effect = [
+        Mock(fetchone=Mock(return_value=None)),
+        Mock(fetchone=Mock(return_value=None)),
+        None,
+    ]
+    tracker = PlaylistTracker(youtube, db, channel_id="UC123")
+    result = tracker._process_video("vid1", "UC123", "PL99")
+    assert result is False
+
+
+def test_run():
+    youtube = Mock()
+    youtube.get_user_playlists.return_value = [
+        type("Playlist", (), {"id": "PL1", "title": "Custom List"}),
+    ]
+    youtube.get_playlist.return_value = [
+        {
+            "snippet": {
+                "resourceId": {"videoId": "vid1"},
+                "videoOwnerChannelId": "UC123",
+                "title": "Video 1",
+                "publishedAt": "2024-01-01T00:00:00Z",
+            }
+        },
+    ]
+    db = MagicMock()
+    db.execute.return_value.fetchall.return_value = []
+    db.execute.return_value.fetchone.side_effect = [
+        None,
+        {"subscriptionId": "sub123"},
+    ]
+
+    tracker = PlaylistTracker(youtube, db, channel_id="UC123")
+    result = tracker.run()
+
+    assert result == {
+        "playlists_processed": 1,
+        "videos_found": 1,
+        "videos_newly_counted": 1,
+        "subscriptions_updated": 1,
+    }
+
+
+def test_upgrade_from_counted_0_to_1():
+    youtube = Mock()
+    db = MagicMock()
+
+    db.execute.return_value.fetchall.return_value = []
+    db.execute.return_value.fetchone.side_effect = [
+        None,
+        None,
+    ]
+
+    tracker = PlaylistTracker(youtube, db, channel_id="UC123")
+    result1 = tracker._process_video("vid1", "UC123", "PL99")
+    assert result1 is False
+
+    db.execute.return_value.fetchone.side_effect = [
+        {"counted": 0},
+        {"subscriptionId": "sub123"},
+    ]
+
+    result2 = tracker._process_video("vid1", "UC123", "PL99")
+    assert result2 is True

--- a/ui/index.html
+++ b/ui/index.html
@@ -150,6 +150,7 @@ label { display: block; font-size: 0.875rem; color: var(--text2); margin-bottom:
   <a class="active" data-page="dashboard" href="#dashboard">Dashboard</a>
   <a data-page="subscriptions" href="#subscriptions">Subscriptions</a>
   <a data-page="pipelines" href="#pipelines">Pipelines</a>
+  <a data-page="videolookup" href="#videolookup">Video Lookup</a>
   <a data-page="config" href="#config">Config</a>
   <a data-page="runs" href="#runs">Pipeline Runs</a>
   <a data-page="stats" href="#stats">Stats</a>
@@ -183,6 +184,17 @@ label { display: block; font-size: 0.875rem; color: var(--text2); margin-bottom:
       <button id="videoSearchBtn" style="padding:0.5rem 1rem">Search</button>
     </div>
     <div id="videoSearchResult" style="display:none"></div>
+  </section>
+  <section id="videolookup" class="page">
+    <h2>Video Lookup</h2>
+    <div style="display:flex;gap:0.5rem;flex-wrap:wrap;margin-bottom:1rem">
+      <input id="videoLookupInput" type="text" placeholder="Enter YouTube video ID (e.g. dQw4w9WgXcQ)" style="flex:1;min-width:300px;padding:0.5rem;border-radius:var(--radius);border:1px solid var(--surface2);background:var(--bg);color:var(--text)">
+      <label style="display:flex;align-items:center;gap:0.5rem;cursor:pointer;font-size:0.875rem;color:var(--text2)">
+        <input type="checkbox" id="showInRuns"> Show in runs
+      </label>
+      <button id="videoLookupBtn" style="padding:0.5rem 1rem">Search</button>
+    </div>
+    <div id="videoLookupResult" style="display:none"></div>
   </section>
   <section id="subscriptions" class="page">
     <h2>Subscriptions</h2>
@@ -331,7 +343,7 @@ function escapeHtml(s) {
 }
 
 // ---- Routing ----
-const PAGES = ['dashboard','subscriptions','pipelines','config','runs','stats','auth'];
+const PAGES = ['dashboard','subscriptions','pipelines','videolookup','config','runs','stats','auth'];
 
 function navigate(page) {
   location.hash = '#' + page;
@@ -409,6 +421,22 @@ renderers.dashboard = async function() {
   } catch { /* cards stay as '-' */ }
 };
 
+// ---- Video Lookup renderer ----
+renderers.videolookup = async function() {
+  const input = document.getElementById('videoLookupInput');
+  const btn = document.getElementById('videoLookupBtn');
+  const resultDiv = document.getElementById('videoLookupResult');
+  const showInRuns = document.getElementById('showInRuns');
+
+  // Let the button click handler do the search
+  // Nothing to render on page load, just wire up Enter key
+  input?.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') btn.click();
+  });
+
+  if (!input || !btn || !resultDiv) return;
+};
+
 // ---- Trigger ----
 document.getElementById('triggerBtn')?.addEventListener('click', async function() {
   this.disabled = true; this.innerHTML = '<span class="spinner"></span>Running...';
@@ -439,36 +467,53 @@ document.getElementById('dryRunBtn')?.addEventListener('click', async function()
   }
 });
 
-// ---- Video Lookup ----
-document.getElementById('videoSearchBtn')?.addEventListener('click', async function() {
-  const input = document.getElementById('videoSearchInput');
-  const resultDiv = document.getElementById('videoSearchResult');
-  const videoId = input.value.trim();
+});
+
+// ---- Video Lookup (shared function) ----
+async function searchVideo(videoId, showRuns, resultDiv, btn) {
   if (!videoId) {
     showToast('Enter a YouTube video ID', 'warning');
     return;
   }
-  this.disabled = true; this.textContent = 'Searching...';
+  btn.disabled = true; btn.textContent = 'Searching...';
   resultDiv.style.display = 'none';
   resultDiv.innerHTML = '';
   try {
-    const data = await api('/api/videos/' + encodeURIComponent(videoId));
+    const [video, runs] = await Promise.all([
+      api('/api/videos/' + encodeURIComponent(videoId)),
+      showRuns ? api('/api/videos/' + encodeURIComponent(videoId) + '/runs') : null,
+    ]);
     resultDiv.style.display = 'block';
+    const runHtml = runs && runs.runs && runs.runs.length > 0
+      ? `<h4 style="margin:1rem 0 0.5rem;color:var(--accent)">Runs containing this video (${runs.total} total)</h4>` +
+        `<table style="width:100%;font-size:0.75rem;border-collapse:collapse">` +
+        `<thead><tr><th>Run</th><th>Started</th><th>Status</th><th>Trigger</th><th>Added</th><th>Skipped</th><th>Errors</th></tr></thead>` +
+        `<tbody>${runs.runs.map(r => `<tr>` +
+          `<td style="font-family:monospace"><a href="#run-detail-${r.run_id}" style="color:var(--accent)">${r.run_id}</a></td>` +
+          `<td style="font-size:0.7rem">${formatTime(r.started_at)}</td>` +
+          `<td>${statusBadge(r.status)}</td>` +
+          `<td>${r.trigger}${r.dry_run ? ' <span class="tag-dryrun">DRY</span>' : ''}</td>` +
+          `<td>${r.videos_added ?? '-'}</td>` +
+          `<td>${r.videos_skipped ?? '-'}</td>` +
+          `<td>${r.errors ?? '-'}</td>` +
+        `</tr>`).join('')}</tbody></table>`
+      : '';
     resultDiv.innerHTML = `
       <div class="card" style="margin-top:0.5rem">
         <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem">
-          <h4 style="margin:0;color:var(--accent)">${escapeHtml(data.title || 'Unknown')}</h4>
-          <code style="font-size:0.75rem;color:var(--text2)">${escapeHtml(data.video_id)}</code>
+          <h4 style="margin:0;color:var(--accent)">${escapeHtml(video.title || 'Unknown')}</h4>
+          <code style="font-size:0.75rem;color:var(--text2)">${escapeHtml(video.video_id)}</code>
         </div>
         <table style="width:100%;font-size:0.8rem;border-collapse:collapse">
-          <tr><td style="color:var(--text2);padding:0.25rem 0">Pipeline</td><td style="text-align:right;font-family:monospace">${escapeHtml(data.pipeline_id || '—')}</td></tr>
-          <tr><td style="color:var(--text2);padding:0.25rem 0">Subscription</td><td style="text-align:right;font-family:monospace">${escapeHtml(data.subscription_id || '—')}</td></tr>
-          <tr><td style="color:var(--text2);padding:0.25rem 0">Playlist</td><td style="text-align:right;font-family:monospace">${escapeHtml(data.playlist_id || '—')}</td></tr>
-          <tr><td style="color:var(--text2);padding:0.25rem 0">Duration</td><td style="text-align:right">${data.duration_seconds ? Math.floor(data.duration_seconds/60)+'m '+(data.duration_seconds%60)+'s' : '—'}</td></tr>
-          <tr><td style="color:var(--text2);padding:0.25rem 0">Added</td><td style="text-align:right;font-family:monospace;font-size:0.7rem">${escapeHtml(data.timestamp || '—')}</td></tr>
-          <tr><td style="color:var(--text2);padding:0.25rem 0">Route Rule</td><td style="text-align:right;font-family:monospace;font-size:0.7rem">${escapeHtml(data.route_rule || '—')}</td></tr>
+          <tr><td style="color:var(--text2);padding:0.25rem 0">Pipeline</td><td style="text-align:right;font-family:monospace">${escapeHtml(video.pipeline_id || '—')}</td></tr>
+          <tr><td style="color:var(--text2);padding:0.25rem 0">Subscription</td><td style="text-align:right;font-family:monospace">${escapeHtml(video.subscription_id || '—')}</td></tr>
+          <tr><td style="color:var(--text2);padding:0.25rem 0">Playlist</td><td style="text-align:right;font-family:monospace">${escapeHtml(video.playlist_id || '—')}</td></tr>
+          <tr><td style="color:var(--text2);padding:0.25rem 0">Duration</td><td style="text-align:right">${video.duration_seconds ? Math.floor(video.duration_seconds/60)+'m '+(video.duration_seconds%60)+'s' : '—'}</td></tr>
+          <tr><td style="color:var(--text2);padding:0.25rem 0">Added</td><td style="text-align:right;font-family:monospace;font-size:0.7rem">${escapeHtml(video.timestamp || '—')}</td></tr>
+          <tr><td style="color:var(--text2);padding:0.25rem 0">Route Rule</td><td style="text-align:right;font-family:monospace;font-size:0.7rem">${escapeHtml(video.route_rule || '—')}</td></tr>
         </table>
         <p style="margin-top:0.5rem;color:var(--success);font-size:0.8rem">✓ Found in database</p>
+        ${runHtml}
       </div>
     `;
     showToast('Video found', 'success');
@@ -485,8 +530,37 @@ document.getElementById('videoSearchBtn')?.addEventListener('click', async funct
       showToast('Error: ' + e.message, 'error');
     }
   } finally {
-    this.disabled = false; this.textContent = 'Search';
+    btn.disabled = false; btn.textContent = 'Search';
   }
+}
+
+// ---- Dashboard Video Search ----
+document.getElementById('videoSearchBtn')?.addEventListener('click', async function() {
+  const input = document.getElementById('videoSearchInput');
+  const resultDiv = document.getElementById('videoSearchResult');
+  const videoId = input.value.trim();
+  if (!videoId) { showToast('Enter a YouTube video ID', 'warning'); return; }
+  await searchVideo(videoId, false, resultDiv, this);
+});
+
+// Allow Enter key in dashboard input
+document.getElementById('videoSearchInput')?.addEventListener('keydown', function(e) {
+  if (e.key === 'Enter') document.getElementById('videoSearchBtn').click();
+});
+
+// ---- Video Lookup page Search ----
+document.getElementById('videoLookupBtn')?.addEventListener('click', async function() {
+  const input = document.getElementById('videoLookupInput');
+  const resultDiv = document.getElementById('videoLookupResult');
+  const showRuns = document.getElementById('showInRuns')?.checked || false;
+  const videoId = input.value.trim();
+  if (!videoId) { showToast('Enter a YouTube video ID', 'warning'); return; }
+  await searchVideo(videoId, showRuns, resultDiv, this);
+});
+
+// Allow Enter key in videolookup input
+document.getElementById('videoLookupInput')?.addEventListener('keydown', function(e) {
+  if (e.key === 'Enter') document.getElementById('videoLookupBtn').click();
 });
 
 // Allow Enter key in input

--- a/ui/index.html
+++ b/ui/index.html
@@ -117,6 +117,7 @@ tr:hover td { background: var(--surface2); }
 .badge-ok { background: var(--success); color: #0f172a; }
 .badge-fail { background: var(--error); color: #fff; }
 .badge-run { background: var(--warning); color: #0f172a; }
+.badge-playlist { background: var(--accent); color: var(--bg); border-radius: 999px; padding: 0.1rem 0.5rem; font-size: 0.75rem; font-weight: 600; margin-left: 0.5rem; white-space: nowrap; }
 .tag-dryrun { background: var(--surface2); color: var(--accent); font-size: 0.65rem; font-weight: 700; padding: 0.1rem 0.4rem; border-radius: 4px; border: 1px solid var(--accent); }
 input, select {
   background: var(--bg); color: var(--text); border: 1px solid var(--surface2);
@@ -576,7 +577,7 @@ renderers.subscriptions = async function() {
     const subs = await api('/api/subscriptions');
     container.innerHTML = `<table><thead><tr><th>Channel</th><th>Channel ID</th></tr></thead>
       <tbody>${Array.isArray(subs) ? subs.map(s => `<tr data-cid="${escapeHtml(s.channel_id)}" class="sub-row" style="cursor:pointer">
-        <td>${escapeHtml(s.title)}</td><td style="color:var(--text2);font-size:0.75rem">${escapeHtml(s.channel_id)}</td>
+        <td>${escapeHtml(s.title)}${s.added_to_playlist_count > 0 ? `<span class="badge badge-playlist" title="Videos in other playlists">📋 ${s.added_to_playlist_count}</span>` : ''}</td><td style="color:var(--text2);font-size:0.75rem">${escapeHtml(s.channel_id)}</td>
       </tr>`).join('') : ''}</tbody></table>`;
     document.getElementById('subSearch').oninput = function() {
       const q = this.value.toLowerCase();
@@ -1149,11 +1150,13 @@ renderers.stats = async function() {
       container.innerHTML = `<table><thead><tr>
         <th style="cursor:pointer" onclick="setStatsSort('subscription_title')">Subscription${arrow('subscription_title')}</th>
         <th style="cursor:pointer" onclick="setStatsSort('videos_added')">Videos Added${arrow('videos_added')}</th>
+        <th style="cursor:pointer" onclick="setStatsSort('added_to_playlist_count')">In Playlists${arrow('added_to_playlist_count')}</th>
         <th style="cursor:pointer" onclick="setStatsSort('last_added_at')">Last Added${arrow('last_added_at')}</th>
         <th style="cursor:pointer" onclick="setStatsSort('status')">Status${arrow('status')}</th>
       </tr></thead><tbody>${sorted.map(d => `<tr>
         <td>${escapeHtml(d.subscription_title)}</td>
         <td>${d.videos_added}</td>
+        <td>${d.added_to_playlist_count || 0}</td>
         <td style="font-size:0.75rem;color:var(--text2)">${formatTime(d.last_added_at)}</td>
         <td><span class="badge ${statusClass(d.status)}">${d.status}</span></td>
       </tr>`).join('')}</tbody></table>


### PR DESCRIPTION
Track which pipeline-routed videos the user manually adds to non-pipeline YouTube playlists. Daily cron job cross-references playlist videos against the `videos` table, increments per-subscription `added_to_playlist_count`, exposes in API and UI.

### Changes
- V6/V7 DB migrations: `playlist_video_tracking` table + `added_to_playlist_count` column on `subscription`
- New `PlaylistTracker` core module with 6 tests
- Daily cron job (3AM, configurable) + manual `POST /api/playlist-tracker/trigger` endpoint
- API exposes count in subscriptions + stats responses
- UI badge on subscriptions view + column in Stats page
- 118 tests passing, ruff clean