### PR TITLE
feat: show pipeline name on runs page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,9 @@ __pycache__
 *.pdb
 *.egg-info
 docs/superpowers/
-.opencode/
-graphify-out
-.worktrees
-node_modules/
 .playwright-mcp/
+graphify-out
+.opencode/
+.worktrees
+.omo/
+node_modules/

--- a/src/sortarr/api/models.py
+++ b/src/sortarr/api/models.py
@@ -161,6 +161,8 @@ class PipelineRunResponse(BaseModel):
     pipelines_invoked: int = 0
     pipelines_with_errors: int = 0
     dry_run: bool = False
+    pipeline_id: Optional[str] = None
+    pipeline_name: Optional[str] = None
 
 
 class RunDecisionResponse(BaseModel):

--- a/src/sortarr/core/pipeline_runner.py
+++ b/src/sortarr/core/pipeline_runner.py
@@ -16,7 +16,9 @@ log = logging.getLogger("sortarr.core.pipeline_runner")
 
 async def execute_pipeline(state, trigger="manual", dry_run=False, pipeline_id=None):
     require_youtube(state)
-    run_id = pr.create_pipeline_run(state.db_con, trigger=trigger, dry_run=dry_run)
+    run_id = pr.create_pipeline_run(
+        state.db_con, trigger=trigger, dry_run=dry_run, pipeline_id=pipeline_id
+    )
     if run_id is None:
         log.error("Failed to create pipeline run")
         return None

--- a/src/sortarr/db/migrations.py
+++ b/src/sortarr/db/migrations.py
@@ -240,6 +240,11 @@ CREATE TABLE IF NOT EXISTS playlist_video_tracking (
             con,
             "ALTER TABLE subscription ADD COLUMN added_to_playlist_count INTEGER NOT NULL DEFAULT 0",
         )
+        # V8: pipeline_id on pipeline_runs
+        _run_migration_safe(
+            con,
+            "ALTER TABLE pipeline_runs ADD COLUMN pipeline_id TEXT",
+        )
         con.commit()
         con.close()
         return True

--- a/src/sortarr/db/repository/pipeline_runs.py
+++ b/src/sortarr/db/repository/pipeline_runs.py
@@ -20,13 +20,16 @@ __all__ = [
 
 
 def create_pipeline_run(
-    con: sqlite3.Connection, trigger: str = "scheduled", dry_run: bool = False
+    con: sqlite3.Connection,
+    trigger: str = "scheduled",
+    dry_run: bool = False,
+    pipeline_id: str | None = None,
 ) -> Optional[int]:
     now = datetime.now(timezone.utc).isoformat()
     try:
         cursor = con.execute(
-            "INSERT INTO pipeline_runs (started_at, status, trigger, dry_run) VALUES (?, 'running', ?, ?)",
-            (now, trigger, int(dry_run)),
+            "INSERT INTO pipeline_runs (started_at, status, trigger, dry_run, pipeline_id) VALUES (?, 'running', ?, ?, ?)",
+            (now, trigger, int(dry_run), pipeline_id),
         )
         con.commit()
         return cursor.lastrowid
@@ -65,7 +68,14 @@ def finish_pipeline_run(con: sqlite3.Connection, run_id: int, summary: dict) -> 
 
 def get_pipeline_runs(con: sqlite3.Connection, limit: int = 20) -> list[dict]:
     cursor = con.execute(
-        "SELECT * FROM pipeline_runs ORDER BY id DESC LIMIT ?", (limit,)
+        """
+        SELECT pr.*, p.name AS pipeline_name
+        FROM pipeline_runs pr
+        LEFT JOIN pipelines p ON pr.pipeline_id = p.id
+        ORDER BY pr.id DESC
+        LIMIT ?
+        """,
+        (limit,),
     )
     return [dict(row) for row in cursor.fetchall()]
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -1771,12 +1771,13 @@ renderers.runs = async function() {
     }
     container.innerHTML =
       '<div class="table-wrap"><table><thead><tr>' +
-      '<th>ID</th><th>Started</th><th>Status</th><th>Trigger</th><th>Subs Proc</th><th>Subs Skip</th><th>Added</th><th>Vid Skip</th><th>Errors</th><th></th>' +
+      '<th>ID</th><th>Started</th><th>Status</th><th>Pipeline</th><th>Trigger</th><th>Subs Proc</th><th>Subs Skip</th><th>Added</th><th>Vid Skip</th><th>Errors</th><th></th>' +
       '</tr></thead><tbody>' + runs.map(r =>
         '<tr style="cursor:pointer" onclick="location.hash=\'#run-detail-' + r.id + '\'">' +
         '<td class="mono">' + r.id + '</td>' +
         '<td style="font-size:0.75rem;color:var(--text-tertiary)">' + formatTime(r.started_at) + '</td>' +
         '<td>' + statusBadge(r.status) + '</td>' +
+        '<td style="font-size:0.75rem;color:var(--text-tertiary)">' + (r.pipeline_name || '-') + '</td>' +
         '<td>' + (r.trigger || '-') + (r.dry_run ? ' <span class="tag-dryrun">DRY</span>' : '') + '</td>' +
         '<td class="num">' + (r.subscriptions_processed ?? '-') + '</td>' +
         '<td class="num">' + (r.subscriptions_skipped ?? '-') + '</td>' +


### PR DESCRIPTION
## Summary
Pipeline runs now store `pipeline_id` when triggered for a single pipeline.
Runs page displays pipeline name column, so users can identify which run
belongs to which pipeline.

## Changes
- Migration V8: add `pipeline_id TEXT` to `pipeline_runs`
- `create_pipeline_run()` accepts optional `pipeline_id`
- `get_pipeline_runs()` LEFT JOINs `pipelines` table for `pipeline_name`
- `PipelineRunResponse` gains `pipeline_id` / `pipeline_name`
- `execute_pipeline()` passes `pipeline_id` on single-pipeline runs
- Runs UI table has new Pipeline column

## Verification
- `ruff check` — all passed
- PipelineRunResponse model serialization verified
- Migration creates `pipeline_id` column on fresh DB
- Repository roundtrip (create with pipeline_id → read back) works