### PR TITLE
fix: log decisions when pipeline subscription has no activity

### DIFF
--- a/src/sortarr/core/pipeline.py
+++ b/src/sortarr/core/pipeline.py
@@ -221,8 +221,32 @@ class PipelineOrchestrator:
                         pass
 
                 # 2.3: Get cached activities
-                activities = activity_cache.get(sub.id, [])
+                if sub.id not in activity_cache:
+                    summary.subscriptions_skipped += 1
+                    skip = dict(
+                        subscription_id=sub.id,
+                        subscription_title=sub.title,
+                        channel_id=sub.channel_id,
+                        reason="api_error",
+                        reason_detail="Failed to fetch activity for this subscription",
+                    )
+                    summary.subscription_skips.append(skip)
+                    if self.on_progress:
+                        self.on_progress(skip, summary)
+                    continue
+                activities = activity_cache[sub.id]
                 if not activities:
+                    summary.subscriptions_skipped += 1
+                    skip = dict(
+                        subscription_id=sub.id,
+                        subscription_title=sub.title,
+                        channel_id=sub.channel_id,
+                        reason="no_new_activity",
+                        reason_detail="No recent activity found for this subscription",
+                    )
+                    summary.subscription_skips.append(skip)
+                    if self.on_progress:
+                        self.on_progress(skip, summary)
                     continue
 
                 summary.subscriptions_processed += 1


### PR DESCRIPTION
## Problem
When a targeted subscription has no recent YouTube activity (or the API call
failed), the pipeline silently skipped it at `pipeline.py:224-226` without
recording any decision. The run showed as completed with zero decisions,
leaving users unable to tell what happened.

## Fix
Replace silent `continue` with explicit skip decisions:
- `api_error` — subscription was not cached (API call failed)
- `no_new_activity` — API returned zero recent activities

Both log a `subscription_skipped` decision with a clear reason, visible in
the run detail page's Subscription Skips section.

## Verification
- `ruff check` — all passed
- Pre-commit hooks passed