### PR TITLE
fix: include subscription_id/channel_id in run decisions and add lookback window to skip details

### DIFF
--- a/src/sortarr/core/pipeline.py
+++ b/src/sortarr/core/pipeline.py
@@ -221,6 +221,7 @@ class PipelineOrchestrator:
                         pass
 
                 # 2.3: Get cached activities
+                pub_after = self._compute_published_after(sub)
                 if sub.id not in activity_cache:
                     summary.subscriptions_skipped += 1
                     skip = dict(
@@ -228,7 +229,9 @@ class PipelineOrchestrator:
                         subscription_title=sub.title,
                         channel_id=sub.channel_id,
                         reason="api_error",
-                        reason_detail="Failed to fetch activity for this subscription",
+                        reason_detail=(
+                            f"Failed to fetch activity. Lookback: from {pub_after}"
+                        ),
                     )
                     summary.subscription_skips.append(skip)
                     if self.on_progress:
@@ -242,7 +245,9 @@ class PipelineOrchestrator:
                         subscription_title=sub.title,
                         channel_id=sub.channel_id,
                         reason="no_new_activity",
-                        reason_detail="No recent activity found for this subscription",
+                        reason_detail=(
+                            f"No recent activity. Lookback: from {pub_after}"
+                        ),
                     )
                     summary.subscription_skips.append(skip)
                     if self.on_progress:

--- a/src/sortarr/db/repository/pipeline_runs.py
+++ b/src/sortarr/db/repository/pipeline_runs.py
@@ -120,7 +120,7 @@ def get_run_decisions(
     con: sqlite3.Connection, run_id: int, limit: int = 1000
 ) -> list[dict]:
     cursor = con.execute(
-        "SELECT id, video_id, title, subscription_title, action, reason, reason_detail, routed_to, created_at "
+        "SELECT id, video_id, title, subscription_id, subscription_title, channel_id, action, reason, reason_detail, routed_to, created_at "
         "FROM pipeline_run_decisions WHERE run_id = ? ORDER BY id ASC LIMIT ?",
         (run_id, limit),
     )


### PR DESCRIPTION
## Fix

**Bug: subscription link broken on run detail page**
`get_run_decisions` SELECT was missing `subscription_id` and `channel_id`. Data was stored but never read back → links rendered as `youtube.com/channel/` (empty).

**Add lookback window to skip details**
Skip decisions now include the lookback date in `reason_detail`, e.g. `No recent activity. Lookback: from 2025-06-19`.

## Changes
- `pipeline_runs.py`: Add `subscription_id` and `channel_id` to `get_run_decisions` SELECT
- `pipeline.py`: Call `_compute_published_after` per skipped sub, include date in `reason_detail`