### PR TITLE
fix(pipeline): decouple Phase 1 lookback from cross-pipeline tracking + add pipeline sorting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Rules:
 - Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
 - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
 
-## Knowledge bundle (OKF) — MANDATORY maintenance
+## Knowledge bundle (OKF) - MANDATORY maintenance
 
 `knowledge/` is a curated OKF knowledge bundle (markdown + YAML frontmatter) that
 agents and humans read to understand this project. **It is part of the source
@@ -20,7 +20,7 @@ tree, not optional documentation.** A change that makes a concept doc inaccurate
 is an incomplete change.
 
 **Rule: if you change source, you MUST update the matching concept doc in the
-SAME change — before you consider the task done.** Treat a stale doc the same as
+SAME change - before you consider the task done.** Treat a stale doc the same as
 a failing test: a blocker, not a follow-up.
 
 Source → doc mapping (touching the left column REQUIRES checking the right):
@@ -37,7 +37,7 @@ Source → doc mapping (touching the left column REQUIRES checking the right):
 | module layout / new packages                        | `knowledge/concepts/architecture.md` + `knowledge/index.md` |
 | build, deps, make targets, CI, Docker, K8s          | `knowledge/concepts/dev-workflow.md`                        |
 
-Definition of done — ALL must hold before finishing a code change:
+Definition of done - ALL must hold before finishing a code change:
 
 - [ ] Every doc in the mapping above whose source you touched has been updated (or you confirmed it is still accurate).
 - [ ] You bumped the `timestamp:` frontmatter on every doc you edited (UTC ISO8601).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,45 @@ This project has a knowledge graph at graphify-out/ with god nodes, community st
 When the user types `/graphify`, invoke the `skill` tool with `skill: "graphify"` before doing anything else.
 
 Rules:
+
 - For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
 - Dirty graphify-out/ files are expected after hooks or incremental updates; dirty graph files are not a reason to skip graphify. Only skip graphify if the task is about stale or incorrect graph output, or the user explicitly says not to use it.
 - If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
 - Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
 - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+
+## Knowledge bundle (OKF) — MANDATORY maintenance
+
+`knowledge/` is a curated OKF knowledge bundle (markdown + YAML frontmatter) that
+agents and humans read to understand this project. **It is part of the source
+tree, not optional documentation.** A change that makes a concept doc inaccurate
+is an incomplete change.
+
+**Rule: if you change source, you MUST update the matching concept doc in the
+SAME change — before you consider the task done.** Treat a stale doc the same as
+a failing test: a blocker, not a follow-up.
+
+Source → doc mapping (touching the left column REQUIRES checking the right):
+
+| If you change…                                      | You MUST review/update…                                     |
+| --------------------------------------------------- | ----------------------------------------------------------- |
+| `src/sortarr/config.py` (any `SORTARR_*` field)     | `knowledge/concepts/runtime-config.md`                      |
+| `src/sortarr/core/pipeline.py` (phases, skip rules) | `knowledge/concepts/pipeline.md`                            |
+| `src/sortarr/filters/**`                            | `knowledge/concepts/filters.md`                             |
+| `src/sortarr/db/**` (schema, migrations, repos)     | `knowledge/concepts/database.md`                            |
+| `src/sortarr/api/**` (routes, app, deps)            | `knowledge/concepts/api.md`                                 |
+| `src/sortarr/core/auth.py`, `api/routes/auth.py`    | `knowledge/concepts/auth.md`                                |
+| `src/sortarr/core/scheduler.py`, schedules          | `knowledge/concepts/scheduler.md`                           |
+| module layout / new packages                        | `knowledge/concepts/architecture.md` + `knowledge/index.md` |
+| build, deps, make targets, CI, Docker, K8s          | `knowledge/concepts/dev-workflow.md`                        |
+
+Definition of done — ALL must hold before finishing a code change:
+
+- [ ] Every doc in the mapping above whose source you touched has been updated (or you confirmed it is still accurate).
+- [ ] You bumped the `timestamp:` frontmatter on every doc you edited (UTC ISO8601).
+- [ ] Cross-links you added/changed still resolve to existing files under `knowledge/`.
+- [ ] You appended a one-line entry to `knowledge/log.md` describing the change.
+
+If a code change genuinely affects no concept doc, state that explicitly in your
+summary (e.g. "no knowledge/ docs affected") so the omission is a decision, not
+an oversight. Do not defer doc updates to a later task.

--- a/knowledge/concepts/api.md
+++ b/knowledge/concepts/api.md
@@ -1,0 +1,50 @@
+---
+type: HTTP API
+title: Sortarr HTTP API
+description: FastAPI app factory, shared AppState, dependency providers, and the REST routes for config, auth, pipelines, subscriptions, and metrics.
+resource: https://github.com/Sea-Shell/sortarr/tree/main/src/sortarr/api
+tags: [sortarr, api, fastapi, rest]
+timestamp: 2026-06-24T10:00:00Z
+---
+
+# App factory
+
+`src/sortarr/api/app.py` exposes `create_app()` which builds the FastAPI app and
+a `lifespan()` context. Shared state lives in `AppState` (settings, DB
+`Connection`, `YouTubeAPIClient`, scheduler) and is reached in handlers via
+`deps.py`:
+
+- `get_state()` — returns the `AppState`
+- `require_youtube()` — dependency that 401/409s if not authenticated
+
+Served by `uvicorn` on `SORTARR_API_PORT` (default 8080). Web UI at `/ui`.
+
+# Routes
+
+Route modules in `src/sortarr/api/routes/`:
+
+| Module                | Endpoints (summary)                                                                                              |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `health.py`           | `GET /api/health`                                                                                                |
+| `config.py`           | `GET/PUT /api/config`, `GET/POST /api/config/ignores`, `DELETE /api/config/ignores/{id}`                         |
+| `auth.py`             | `GET /api/auth/status`, `POST /api/auth/device`, `POST /api/auth/poll` — see [auth](/knowledge/concepts/auth.md) |
+| `subscriptions.py`    | `GET /api/subscriptions`, `GET /api/subscriptions/{cid}/activity`                                                |
+| `rules.py`            | CRUD `/api/rules` (legacy routing rules)                                                                         |
+| `pipelines.py`        | CRUD pipelines, selectors, attachments                                                                           |
+| `pipeline.py`         | `POST /api/pipeline/trigger`, `GET /api/pipeline/runs`, `GET /api/pipeline/runs/{id}`                            |
+| `playlist_tracker.py` | Playlist reconciliation endpoints                                                                                |
+| `stats.py`            | Aggregate stats                                                                                                  |
+| (root)                | `GET /metrics` — Prometheus                                                                                      |
+
+# Triggering a run
+
+`POST /api/pipeline/trigger` runs the **same** logic as the
+[scheduler](/knowledge/concepts/scheduler.md), via `pipeline_runner.execute_pipeline`,
+which constructs a [`PipelineOrchestrator`](/knowledge/concepts/pipeline.md) and
+persists results to `pipeline_runs` in the [database](/knowledge/concepts/database.md).
+
+# Models
+
+Request/response models are pydantic (`api/models.py` and `models/`):
+`HealthResponse`, `PipelineCreate/Update/Response`, `IgnoreList*`,
+`PipelineRunResponse`, etc.

--- a/knowledge/concepts/api.md
+++ b/knowledge/concepts/api.md
@@ -4,7 +4,7 @@ title: Sortarr HTTP API
 description: FastAPI app factory, shared AppState, dependency providers, and the REST routes for config, auth, pipelines, subscriptions, and metrics.
 resource: https://github.com/Sea-Shell/sortarr/tree/main/src/sortarr/api
 tags: [sortarr, api, fastapi, rest]
-timestamp: 2026-06-24T10:00:00Z
+timestamp: 2026-06-24T12:00:00Z
 ---
 
 # App factory
@@ -46,5 +46,13 @@ persists results to `pipeline_runs` in the [database](/knowledge/concepts/databa
 # Models
 
 Request/response models are pydantic (`api/models.py` and `models/`):
-`HealthResponse`, `PipelineCreate/Update/Response`, `IgnoreList*`,
-`PipelineRunResponse`, etc.
+`HealthResponse`, `PipelineCreate/Update/Response`, `ReorderRequest`,
+`IgnoreList*`, `PipelineRunResponse`, etc.
+
+### Pipeline Reorder API
+
+`PUT /api/pipelines/reorder` accepts `ReorderRequest { pipeline_ids: list[str] }`
+and assigns sequential `sort_order` (0, 1, 2, ...) based on position in the list.
+The handler validates the list is non-empty and returns 400 if empty, 500 on DB
+failure. This replaced the previous swap-based `orders` dict API to fix the
+issue where all pipelines had `sort_order=0` and swapping was a no-op.

--- a/knowledge/concepts/architecture.md
+++ b/knowledge/concepts/architecture.md
@@ -1,0 +1,69 @@
+---
+type: Architecture
+title: Sortarr Architecture
+description: Module layout of src/sortarr, the core abstractions, and how a pipeline run and an HTTP request flow through the system.
+resource: https://github.com/Sea-Shell/sortarr/tree/main/src/sortarr
+tags: [sortarr, architecture, overview]
+timestamp: 2026-06-24T10:00:00Z
+---
+
+# Module Layout
+
+```
+src/sortarr/
+├── __main__.py        # entry point: `python -m sortarr` → main()
+├── config.py          # Settings (pydantic-settings, env_prefix SORTARR_)
+├── metrics.py         # Prometheus metrics
+├── api/               # FastAPI app, routes, dependencies  → see api.md
+│   ├── app.py         # create_app(), lifespan(), AppState
+│   ├── deps.py        # get_state(), require_youtube()
+│   └── routes/        # auth, config, health, pipeline, pipelines,
+│                      #   playlist_tracker, rules, stats, subscriptions
+├── core/              # business logic
+│   ├── pipeline.py        # PipelineOrchestrator  → see pipeline.md
+│   ├── pipeline_runner.py # execute a run, persist results
+│   ├── scheduler.py       # APScheduler wiring   → see scheduler.md
+│   ├── playlist_tracker.py# nightly playlist reconciliation
+│   ├── auth.py            # OAuth flow           → see auth.md
+│   ├── youtube.py         # YouTubeAPIClient (god node, 34 edges)
+│   └── utils.py
+├── db/                # persistence              → see database.md
+│   ├── connection.py  # Connection (god node, 56 edges)
+│   ├── migrations.py  # auto-run on startup
+│   └── repository/    # config, ignore_lists, pipeline, pipeline_runs, videos
+├── filters/           # routing filters          → see filters.md
+└── models/            # pydantic: pipeline.py, youtube.py (Channel, Playlist, Activity)
+```
+
+# Core Abstractions
+
+Per the graphify graph report, the most-connected ("god") nodes are:
+
+| Abstraction            | Role                                                                        |
+| ---------------------- | --------------------------------------------------------------------------- |
+| `Connection` (sqlite3) | Threaded through nearly everything; the DB handle                           |
+| `YouTubeAPIClient`     | All YouTube Data API calls live here                                        |
+| `Activity`             | A discovered video (id, title, published_at, type)                          |
+| `Channel` / `Playlist` | The authenticated user's own channel + target playlists                     |
+| `PipelineOrchestrator` | Drives a full routing run — see [pipeline](/knowledge/concepts/pipeline.md) |
+
+# Flow: A Pipeline Run
+
+1. [Scheduler](/knowledge/concepts/scheduler.md) (or a manual trigger) starts a run.
+2. [`PipelineOrchestrator`](/knowledge/concepts/pipeline.md) fetches subscriptions
+   via `YouTubeAPIClient`, caches activities in the [DB](/knowledge/concepts/database.md).
+3. Each enabled pipeline applies its [filters](/knowledge/concepts/filters.md) and
+   routes surviving videos into a destination playlist.
+4. Results persist to `pipeline_runs`; progress streams via an `on_progress` callback.
+
+# Flow: An HTTP Request
+
+`uvicorn` → FastAPI app from [`create_app()`](/knowledge/concepts/api.md) → route
+handler → reads shared `AppState` (settings, DB `Connection`, YouTube client) via
+`deps.py` → repository call against [SQLite](/knowledge/concepts/database.md).
+
+# Note on naming
+
+The package was renamed from `ys2wl` to `sortarr`. Older graphify cache entries
+and a legacy K8s CronJob manifest still reference `ys2wl` paths; current source
+lives under `src/sortarr/`.

--- a/knowledge/concepts/auth.md
+++ b/knowledge/concepts/auth.md
@@ -1,0 +1,47 @@
+---
+type: Process
+title: Sortarr Authentication
+description: Google OAuth flow for accessing the YouTube Data API — authorization URL, code exchange, credential storage, device/headless mode.
+resource: https://github.com/Sea-Shell/sortarr/blob/main/src/sortarr/core/auth.py
+tags: [sortarr, auth, oauth, youtube, google]
+timestamp: 2026-06-24T10:00:00Z
+---
+
+# Why auth exists
+
+`sortarr` acts on the user's own YouTube account (read subscriptions, write to
+playlists), so it needs an OAuth2 access/refresh token for the YouTube Data API.
+The [`YouTubeAPIClient`](/knowledge/concepts/architecture.md) uses those
+credentials for every call.
+
+# Credential inputs
+
+- **Client config**: a Google OAuth client JSON (`SORTARR_CREDENTIALS_FILE`,
+  default `client_secret.json`), or stored in the DB. `get_client_config()` /
+  `_extract client_id and client_secret from the credentials JSON in DB`.
+- **Token storage**: `SORTARR_PICKLE_FILE` (default `credentials.pickle`) holds
+  the obtained OAuth credentials. See [runtime config](/knowledge/concepts/runtime-config.md).
+
+# Flow (core/auth.py + api/routes/auth.py)
+
+1. `get_authorization_url()` builds the Google OAuth consent URL (redirect back
+   to `public_url`).
+2. User authorizes; the app receives a code.
+3. `exchange_code_for_tokens(code)` swaps it for OAuth credentials, which are
+   persisted (pickle/DB).
+4. `load_credentials()` / `credentials_status()` restore and report auth state;
+   `GET /api/auth/status` surfaces it to the UI.
+
+A device-style flow is exposed over HTTP: `POST /api/auth/device` starts it and
+`POST /api/auth/poll` waits for completion — see [API](/knowledge/concepts/api.md).
+
+# Headless mode
+
+Set `SORTARR_NO_WEBBROWSER=true` to skip launching a local browser (for servers
+/ containers); complete the consent step manually with the printed URL.
+
+# Gotcha
+
+`require_youtube()` (in `deps.py`) guards routes that need an authenticated
+client — endpoints fail clearly if credentials are missing or expired rather
+than erroring deep in a pipeline run.

--- a/knowledge/concepts/database.md
+++ b/knowledge/concepts/database.md
@@ -1,0 +1,54 @@
+---
+type: Datastore
+title: Sortarr Database
+description: SQLite persistence — connection handling, auto-run migrations, the table schema, and the repository layer that wraps all queries.
+resource: https://github.com/Sea-Shell/sortarr/tree/main/src/sortarr/db
+tags: [sortarr, database, sqlite, persistence]
+timestamp: 2026-06-24T10:00:00Z
+---
+
+# Layout
+
+```
+src/sortarr/db/
+├── connection.py   # opens the sqlite3 Connection (god node, 56 edges)
+├── migrations.py   # schema DDL, auto-run on startup
+└── repository/
+    ├── config.py        # runtime config key/values
+    ├── ignore_lists.py  # ignore lists + entries  → see filters.md
+    ├── pipeline.py      # pipelines, selectors, tracking, list attachments
+    ├── pipeline_runs.py # run history + decisions
+    └── videos.py        # activity cache + routed-video records
+```
+
+The DB path is `SORTARR_DATABASE_FILE` (default `sortarr.db`) — see
+[runtime config](/knowledge/concepts/runtime-config.md).
+
+# Migrations
+
+`migrations.py` defines the schema as SQL (`V1_SCHEMA_SQL`, …) and runs it on
+startup; there is **no separate migrate command**. Tables use
+`CREATE TABLE IF NOT EXISTS`, so startup is idempotent.
+
+# Schema (V1 core tables)
+
+| Table           | Purpose                                                                                                                                             |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `videos`        | `videoId` PK, title, `subscriptionId`, `playlistId`, `duration_seconds`, `route_rule` — activity cache + routed records                             |
+| `channel`       | The authenticated user's channel (`id`, `title`)                                                                                                    |
+| `playlist`      | Known playlists (`id`, `title`)                                                                                                                     |
+| `subscription`  | Subscriptions (`id`, `title`, `timestamp`)                                                                                                          |
+| `last_run`      | Last run timestamp                                                                                                                                  |
+| `routing_rules` | Legacy rule rows: `priority`, `field`, `operator`, `pattern`, `destination_playlist_id`, `enabled`, `minimum_length`, `maximum_length`, `catch_all` |
+| `pipeline_runs` | Run history (see `pipeline_runs` repository)                                                                                                        |
+
+Pipelines, selectors, ignore lists, and pipeline↔subscription/ignore-list
+attachments are managed through the `pipeline` and `ignore_lists` repositories.
+
+# Repository pattern
+
+Handlers and the [pipeline](/knowledge/concepts/pipeline.md) never write SQL
+inline — they call functions in `repository/` (e.g. `videos.cache_activity`,
+`pipeline.get_pipeline_tracking`, `pipeline.get_pipeline_selectors`). The
+`Connection` is created once and shared through
+[`AppState`](/knowledge/concepts/api.md).

--- a/knowledge/concepts/database.md
+++ b/knowledge/concepts/database.md
@@ -4,7 +4,7 @@ title: Sortarr Database
 description: SQLite persistence — connection handling, auto-run migrations, the table schema, and the repository layer that wraps all queries.
 resource: https://github.com/Sea-Shell/sortarr/tree/main/src/sortarr/db
 tags: [sortarr, database, sqlite, persistence]
-timestamp: 2026-06-24T10:00:00Z
+timestamp: 2026-06-24T12:00:00Z
 ---
 
 # Layout
@@ -41,6 +41,11 @@ startup; there is **no separate migrate command**. Tables use
 | `last_run`      | Last run timestamp                                                                                                                                  |
 | `routing_rules` | Legacy rule rows: `priority`, `field`, `operator`, `pattern`, `destination_playlist_id`, `enabled`, `minimum_length`, `maximum_length`, `catch_all` |
 | `pipeline_runs` | Run history (see `pipeline_runs` repository)                                                                                                        |
+
+The `pipelines` table has a `sort_order INTEGER NOT NULL DEFAULT 0` column
+(added in V9 migration). `get_pipelines()` orders by `sort_order ASC, name ASC`.
+`reorder_pipelines(con, pipeline_ids: list[str])` assigns sequential sort_order
+values (0, 1, 2, …) based on list position.
 
 Pipelines, selectors, ignore lists, and pipeline↔subscription/ignore-list
 attachments are managed through the `pipeline` and `ignore_lists` repositories.

--- a/knowledge/concepts/dev-workflow.md
+++ b/knowledge/concepts/dev-workflow.md
@@ -1,0 +1,65 @@
+---
+type: Runbook
+title: Sortarr Development Workflow
+description: How to install, run, test, lint, type-check, containerize, and deploy sortarr — the commands you reach for every session.
+resource: https://github.com/Sea-Shell/sortarr/blob/main/README.md
+tags: [sortarr, dev, build, test, docker, k8s]
+timestamp: 2026-06-24T10:00:00Z
+---
+
+# Stack
+
+- Python **3.13**, packaged with **uv** (`pyproject.toml`, hatchling build).
+- Runtime: FastAPI + uvicorn[standard], APScheduler, pydantic-settings,
+  google-api-python-client / google-auth(-oauthlib), prometheus-client, httpx,
+  fuzzywuzzy + levenshtein.
+- Version `2.0.0`. Entry point script: `sortarr = sortarr.__main__:main`.
+
+# Run locally
+
+```sh
+uv sync --dev
+uv run python -m sortarr      # serves http://localhost:8080
+```
+
+# Make targets
+
+| Command       | Does                                        |
+| ------------- | ------------------------------------------- |
+| `make sync`   | install dependencies                        |
+| `make test`   | run tests (`pytest`, `asyncio_mode = auto`) |
+| `make lint`   | `ruff check`                                |
+| `make format` | `ruff format`                               |
+| `make check`  | lint + format check                         |
+| `make docker` | build the container image                   |
+
+# Lint / format / types
+
+- `ruff` for lint + format; runs on commit via **pre-commit**
+  (`uv tool install pre-commit && pre-commit install`).
+- Optional type checking: `uv run mypy src/sortarr/`.
+
+# Tests
+
+`pytest` with `pytest-asyncio` (auto mode). Integration tests use a real
+in-process app + DB `Connection` (see graphify "Integration Tests" community);
+no external services required.
+
+# Docker
+
+```sh
+make docker
+docker run -p 8080:8080 -v /path/to/data:/data sortarr
+```
+
+# Kubernetes
+
+Manifests in `k8s/` — `kubectl apply -f k8s/`. The old `cronjob.yaml` is
+superseded by the internal [scheduler](/knowledge/concepts/scheduler.md).
+
+# Knowledge graph
+
+A graphify graph exists at `graphify-out/` (`graph.json`, `GRAPH_REPORT.md`).
+Prefer `graphify query "<question>"` for codebase questions; run
+`graphify update .` after changing code. This OKF bundle complements it with
+hand-curated, navigable summaries.

--- a/knowledge/concepts/filters.md
+++ b/knowledge/concepts/filters.md
@@ -1,0 +1,46 @@
+---
+type: Component
+title: Sortarr Filters
+description: The four filter functions that decide whether a discovered video is routed or skipped — ignore list, word, selector, and fuzzy title similarity.
+resource: https://github.com/Sea-Shell/sortarr/tree/main/src/sortarr/filters
+tags: [sortarr, filters, deduplication, routing]
+timestamp: 2026-06-24T10:00:00Z
+---
+
+# Filter functions
+
+All live in `src/sortarr/filters/` and return a `FilterResult`
+(`passed: bool`, plus reason / `skipped_by` / match metadata). Used by the
+[pipeline](/knowledge/concepts/pipeline.md) during Phase 2.
+
+| Filter               | File                  | Purpose                                                                    |
+| -------------------- | --------------------- | -------------------------------------------------------------------------- |
+| `ignore_list_filter` | `ignore_list.py`      | Reject if video id is in an ignore list                                    |
+| `word_filter`        | `word_filter.py`      | Reject if the title contains an ignored word                               |
+| `selector_filter`    | `selector_filter.py`  | Match against pipeline selectors (field/operator/pattern, combined AND/OR) |
+| `title_similarity`   | `title_similarity.py` | Reject near-duplicate titles already in the DB                             |
+
+# Title similarity (de-duplication)
+
+This is the non-obvious one. `title_similarity(new_title, existing_titles, threshold)`:
+
+1. `_normalize()` lowercases and collapses non-`[a-zA-Z0-9-_]` runs to spaces.
+2. `_fuzz_ratio()` computes a **Levenshtein-based** similarity percentage
+   (0–100) between the normalized new title and each existing title.
+3. If `ratio > threshold`, the video is rejected as a duplicate, citing the
+   matched `video_id` and percentage.
+
+The threshold is `SORTARR_COMPARE_DISTANCE` (default **80**) — see
+[runtime config](/knowledge/concepts/runtime-config.md). The implementation is a
+hand-rolled edit-distance loop; `fuzzywuzzy` / `levenshtein` are also project
+dependencies.
+
+> Search note: this is what answers "how does sortarr detect duplicate videos?"
+> — the code never uses the word "duplicate", it talks about _title similarity_.
+
+# Ignore lists
+
+Ignore lists are DB-backed (managed in the web UI, not `.ignore` files) and typed
+as `video`, `word`, or `subscription`. A pipeline references list ids; the
+orchestrator resolves them into concrete value lists before filtering. See the
+[`ignore_lists` repository](/knowledge/concepts/database.md).

--- a/knowledge/concepts/index.md
+++ b/knowledge/concepts/index.md
@@ -1,0 +1,22 @@
+---
+type: Directory Index
+title: Sortarr Concepts
+description: Index of all concept documents in the sortarr knowledge bundle, with one-line descriptions for progressive disclosure.
+resource: https://github.com/Sea-Shell/sortarr
+tags: [sortarr, index]
+timestamp: 2026-06-24T10:00:00Z
+---
+
+# Concepts
+
+| Concept                                                        | What it covers                                                    |
+| -------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [Architecture](/knowledge/concepts/architecture.md)            | `src/sortarr/` module layout, core abstractions, run/request flow |
+| [Runtime Configuration](/knowledge/concepts/runtime-config.md) | `SORTARR_*` env vars, `Settings`, DB-backed runtime config        |
+| [Pipeline](/knowledge/concepts/pipeline.md)                    | `PipelineOrchestrator` two-phase routing logic                    |
+| [Filters](/knowledge/concepts/filters.md)                      | word / selector / ignore-list / title-similarity filters          |
+| [Database](/knowledge/concepts/database.md)                    | SQLite schema, auto-migrations, repository layer                  |
+| [HTTP API](/knowledge/concepts/api.md)                         | FastAPI app factory, `AppState`, routes, deps                     |
+| [Auth](/knowledge/concepts/auth.md)                            | Google OAuth credential flow and storage                          |
+| [Scheduler](/knowledge/concepts/scheduler.md)                  | APScheduler cron schedules, manual triggers                       |
+| [Dev Workflow](/knowledge/concepts/dev-workflow.md)            | uv, make targets, ruff, pytest, Docker, K8s                       |

--- a/knowledge/concepts/pipeline.md
+++ b/knowledge/concepts/pipeline.md
@@ -1,0 +1,64 @@
+---
+type: Process
+title: Sortarr Pipeline Orchestrator
+description: The two-phase PipelineOrchestrator that collects subscription activity then routes videos into playlists per pipeline, with skip rules.
+resource: https://github.com/Sea-Shell/sortarr/blob/main/src/sortarr/core/pipeline.py
+tags: [sortarr, pipeline, routing, core]
+timestamp: 2026-06-24T10:00:00Z
+---
+
+# Overview
+
+`PipelineOrchestrator` (`src/sortarr/core/pipeline.py`) executes a full routing
+run. It is constructed with `Settings`, a `YouTubeAPIClient`, a DB `Connection`,
+the user's `Channel`/`Playlist`, the list of `PipelineConfig`s, resolved ignore
+lists, a default playlist, and an optional `dry_run` flag and `on_progress`
+callback. Entry point is `_run()`, returning a `PipelineSummary`.
+
+# Phase 1 — Data Collection
+
+`_collect_activities(subscriptions)` fetches activity for **every** subscription
+once via `youtube.get_subscription_activity(...)` and caches each `Activity` into
+the [`videos` cache table](/knowledge/concepts/database.md). Returns
+`{sub_id: [Activity]}`.
+
+The lookback (`published_after`) is computed by `_compute_published_after`:
+
+- use `settings.published_after` if set, else
+- `now - reprocess_days` if `reprocess_days > 0`, else
+- `now - 52 weeks`.
+
+> Deliberately does **not** use per-subscription tracking here, to avoid
+> prematurely narrowing the window when multiple pipelines share a subscription.
+> The per-pipeline freshness check (Phase 2.2) handles reprocessing instead.
+
+# Phase 2 — Per-Pipeline Processing
+
+For each **enabled** `PipelineConfig`:
+
+1. **Resolve ignore lists** attached to the pipeline, bucketed by type into
+   `video` / `word` / `subscription` lists — see [filters](/knowledge/concepts/filters.md).
+2. **Resolve selectors** (`PipelineSelector`: field, operator, pattern,
+   combine_operator AND/OR).
+3. **Determine scope**: `subscription_scope == "selected"` limits to attached
+   subscription ids; otherwise all subscriptions.
+4. For each target subscription, apply skip checks in order:
+   - **2.1 Subscription ignore** — title in `ignore_subs` → skip (`reason="ignored"`).
+   - **2.2 Reprocess window** — if `get_pipeline_tracking` shows it was checked
+     within `reprocess_days`, skip (`reason="already_up_to_date"`).
+   - Then per-video [filters](/knowledge/concepts/filters.md) decide routing.
+
+Surviving videos are inserted into the destination playlist (rate-limited by
+`playlist_sleep`); routed videos are recorded against `route_rule`.
+
+# Outputs
+
+A `PipelineSummary` accumulates `pipelines_invoked`, `subscriptions_skipped`,
+`subscription_skips[]` (with reason/detail), errors, and timing. Progress is
+streamed live through `on_progress(skip_or_result, summary)` for the UI. Results
+persist to `pipeline_runs` via [`pipeline_runner`](/knowledge/concepts/api.md).
+
+# Triggers
+
+Runs start either from the [scheduler](/knowledge/concepts/scheduler.md) or a
+manual `POST /api/pipeline/trigger`. Both use the same code path.

--- a/knowledge/concepts/runtime-config.md
+++ b/knowledge/concepts/runtime-config.md
@@ -1,0 +1,50 @@
+---
+type: Service Configuration
+title: Sortarr Runtime Configuration
+description: SORTARR_* environment variables, the pydantic Settings model, and how DB-backed runtime config relates to env seeding.
+resource: https://github.com/Sea-Shell/sortarr/blob/main/src/sortarr/config.py
+tags: [sortarr, config, settings, env]
+timestamp: 2026-06-24T10:00:00Z
+---
+
+# Two-tier config
+
+1. **Env vars** (`SORTARR_*`) are read by `Settings` (pydantic-settings,
+   `env_prefix="SORTARR_"`, also reads `.env`). They **seed the DB on first run**.
+2. **Runtime config** lives in the [SQLite DB](/knowledge/concepts/database.md) and
+   is edited via the web UI at `/ui#config` or the
+   [`/api/config`](/knowledge/concepts/api.md) endpoint.
+
+> Gotcha: because env vars only _seed_, changing one after the DB exists has no
+> effect. Edit runtime config through the DB/API instead.
+
+# Settings fields
+
+Defined in `src/sortarr/config.py` as `Settings(BaseSettings)`:
+
+| Env var                        | Field                       | Default                 | Notes                                                                            |
+| ------------------------------ | --------------------------- | ----------------------- | -------------------------------------------------------------------------------- |
+| `SORTARR_API_PORT`             | `api_port`                  | `8080`                  | HTTP listen port                                                                 |
+| `SORTARR_LOG_LEVEL`            | `log_level`                 | `warning`               |                                                                                  |
+| `SORTARR_LOG_FILE`             | `log_file`                  | `stream`                | `stream` = stdout                                                                |
+| `SORTARR_DATABASE_FILE`        | `database_file`             | `sortarr.db`            | SQLite path                                                                      |
+| `SORTARR_PICKLE_FILE`          | `pickle_file`               | `credentials.pickle`    | OAuth token — see [auth](/knowledge/concepts/auth.md)                            |
+| `SORTARR_CREDENTIALS_FILE`     | `credentials_file`          | `client_secret.json`    | Google OAuth client JSON                                                         |
+| `SORTARR_SCHEDULE`             | `schedule`                  | `0 */6 * * *`           | Pipeline cron — see [scheduler](/knowledge/concepts/scheduler.md)                |
+| `SORTARR_COMPARE_DISTANCE`     | `compare_distance`          | `80`                    | Title similarity threshold 0–100 — see [filters](/knowledge/concepts/filters.md) |
+| `SORTARR_REPROCESS_DAYS`       | `reprocess_days`            | `2`                     | Days before re-checking a sub                                                    |
+| `SORTARR_PLAYLIST_SLEEP`       | `playlist_sleep`            | `10`                    | Seconds between playlist inserts                                                 |
+| `SORTARR_SUBSCRIPTION_SLEEP`   | `subscription_sleep`        | `30`                    | Seconds between subs                                                             |
+| `SORTARR_PIPELINE_CONCURRENCY` | `pipeline_concurrency`      | `1`                     | 1–10 parallel pipelines                                                          |
+| `SORTARR_ACTIVITY_LIMIT`       | `activity_limit`            | `0`                     | Max activities/sub (0=∞)                                                         |
+| `SORTARR_SUBSCRIPTION_LIMIT`   | `subscription_limit`        | `0`                     | Max subs/run (0=∞)                                                               |
+| `SORTARR_PUBLISHED_AFTER`      | `published_after`           | —                       | ISO8601 lower bound                                                              |
+| `SORTARR_NO_WEBBROWSER`        | `no_webbrowser`             | `false`                 | Headless auth                                                                    |
+| (n/a)                          | `public_url`                | `http://localhost:8080` | Used in OAuth redirects                                                          |
+| (n/a)                          | `playlist_tracker_schedule` | `0 3 * * *`             | Nightly tracker cron                                                             |
+
+# Validation
+
+Some fields are range-constrained at the pydantic level: `compare_distance`
+0–100, `pipeline_concurrency` 1–10, several `ge=0` counters. Out-of-range env
+values fail fast at startup.

--- a/knowledge/concepts/scheduler.md
+++ b/knowledge/concepts/scheduler.md
@@ -1,0 +1,36 @@
+---
+type: Component
+title: Sortarr Scheduler
+description: APScheduler-based internal scheduling that runs the pipeline and playlist tracker on cron expressions, replacing an external Kubernetes CronJob.
+resource: https://github.com/Sea-Shell/sortarr/blob/main/src/sortarr/core/scheduler.py
+tags: [sortarr, scheduler, cron, apscheduler]
+timestamp: 2026-06-24T10:00:00Z
+---
+
+# What it does
+
+The app runs an **internal scheduler (APScheduler)** started with the app
+process (`core/scheduler.py`, wired in the [`lifespan()`](/knowledge/concepts/api.md)).
+No separate Kubernetes CronJob is needed — a legacy `kubernetes-manifests/cronjob.yaml`
+exists but is **superseded** by this internal scheduler.
+
+# Schedules
+
+| Job              | Env var                     | Default cron  | Meaning          |
+| ---------------- | --------------------------- | ------------- | ---------------- |
+| Pipeline run     | `SORTARR_SCHEDULE`          | `0 */6 * * *` | Every 6 hours    |
+| Playlist tracker | `playlist_tracker_schedule` | `0 3 * * *`   | Nightly at 03:00 |
+
+See [runtime config](/knowledge/concepts/runtime-config.md) for the settings.
+
+# Manual vs automatic
+
+A scheduled run and a manual `POST /api/pipeline/trigger` invoke the **same**
+core path ([`PipelineOrchestrator`](/knowledge/concepts/pipeline.md) via
+`pipeline_runner`) — shared logic for DRYness and consistent behavior.
+
+# Concurrency
+
+`SORTARR_PIPELINE_CONCURRENCY` (1–10, default 1) bounds parallel pipeline
+execution within a run. Rate-limit knobs `playlist_sleep` and
+`subscription_sleep` space out API calls to stay within YouTube quota.

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -1,0 +1,33 @@
+---
+type: Bundle Index
+title: Sortarr Knowledge Bundle
+description: Root index for the sortarr OKF knowledge bundle. Start here, then follow links into concepts/ one level at a time.
+resource: https://github.com/Sea-Shell/sortarr
+tags: [sortarr, index, okf]
+timestamp: 2026-06-24T10:00:00Z
+---
+
+# Sortarr Knowledge Bundle
+
+`sortarr` (package `sortarr`, formerly `ys2wl`) is a Python 3.13 web service
+that scrapes YouTube subscriptions and routes new videos into playlists based on
+configurable per-pipeline rules. Built on **FastAPI + uvicorn**, scheduled with
+**APScheduler**, persisted in **SQLite**, authenticated via **Google OAuth**.
+
+This bundle is an [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)
+knowledge base: a directory of markdown files an agent can navigate selectively
+instead of re-reading the codebase each session.
+
+# Concepts
+
+See [concepts/](/knowledge/concepts/index.md) for the full list. Quick links:
+
+- [Architecture](/knowledge/concepts/architecture.md) — module layout and request/run flow
+- [Runtime Configuration](/knowledge/concepts/runtime-config.md) — `SORTARR_*` env vars + DB-backed config
+- [Pipeline](/knowledge/concepts/pipeline.md) — the two-phase orchestrator that routes videos
+- [Filters](/knowledge/concepts/filters.md) — ignore lists, word, selector, title-similarity
+- [Database](/knowledge/concepts/database.md) — SQLite schema, migrations, repository layer
+- [HTTP API](/knowledge/concepts/api.md) — FastAPI app factory, routes, dependencies
+- [Auth](/knowledge/concepts/auth.md) — Google OAuth device + browser flow
+- [Scheduler](/knowledge/concepts/scheduler.md) — APScheduler cron-driven runs
+- [Dev Workflow](/knowledge/concepts/dev-workflow.md) — build, test, lint, Docker, K8s

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -13,3 +13,4 @@ Append a one-line entry whenever you add, edit, or remove a concept doc.
 Format: `- YYYY-MM-DD — <doc(s) touched> — <what changed and why>`
 
 - 2026-06-24 — bundle created — initial OKF bundle: architecture, runtime-config, pipeline, filters, database, api, auth, scheduler, dev-workflow.
+- 2026-06-24 — api.md, database.md — updated for sort_order column, reorder_pipelines function, ReorderRequest model, PUT /pipelines/reorder endpoint.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,0 +1,15 @@
+---
+type: Changelog
+title: Sortarr Knowledge Bundle — Change Log
+description: Chronological record of changes to the knowledge/ OKF bundle. Append one line per change; newest at top.
+resource: https://github.com/Sea-Shell/sortarr
+tags: [sortarr, log, okf, changelog]
+timestamp: 2026-06-24T10:00:00Z
+---
+
+# Change Log
+
+Append a one-line entry whenever you add, edit, or remove a concept doc.
+Format: `- YYYY-MM-DD — <doc(s) touched> — <what changed and why>`
+
+- 2026-06-24 — bundle created — initial OKF bundle: architecture, runtime-config, pipeline, filters, database, api, auth, scheduler, dev-workflow.

--- a/src/sortarr/api/models.py
+++ b/src/sortarr/api/models.py
@@ -111,6 +111,7 @@ class PipelineCreate(BaseModel):
     subscription_scope: str = "all"
     destination_playlist_id: str
     destination_playlist_title: str = ""
+    sort_order: Optional[int] = None
 
 
 class PipelineUpdate(BaseModel):
@@ -125,6 +126,7 @@ class PipelineUpdate(BaseModel):
     subscription_scope: Optional[str] = None
     destination_playlist_id: Optional[str] = None
     destination_playlist_title: Optional[str] = None
+    sort_order: Optional[int] = None
 
 
 class PipelineResponse(BaseModel):
@@ -142,6 +144,7 @@ class PipelineResponse(BaseModel):
     destination_playlist_title: str
     created_at: str
     updated_at: str
+    sort_order: int = 0
     ignore_list_ids: List[str] = Field(default_factory=list)
     selectors: List[dict] = Field(default_factory=list)
     subscription_ids: List[str] = Field(default_factory=list)

--- a/src/sortarr/api/models.py
+++ b/src/sortarr/api/models.py
@@ -97,6 +97,10 @@ class RoutingRuleResponse(BaseModel):
     catch_all: bool = False
 
 
+class ReorderRequest(BaseModel):
+    pipeline_ids: List[str]
+
+
 # --- Pipeline models ---
 
 

--- a/src/sortarr/api/routes/pipelines.py
+++ b/src/sortarr/api/routes/pipelines.py
@@ -6,6 +6,7 @@ from sortarr.api.models import (
     PipelineCreate,
     PipelineUpdate,
     PipelineResponse,
+    ReorderRequest,
     IgnoreListResponse,
     IgnoreListCreate,
     IgnoreListEntryCreate,
@@ -76,12 +77,27 @@ async def create_pipeline(pipeline: PipelineCreate, request: Request):
         check_title_similarity=pipeline.check_title_similarity,
         compare_distance=pipeline.compare_distance,
         subscription_scope=pipeline.subscription_scope,
+        sort_order=pipeline.sort_order,
     )
     if not ok:
         raise HTTPException(status_code=500, detail="Failed to create pipeline")
     pipelines = pl.get_pipelines(state.db_con)
     match = [p for p in pipelines if p["id"] == pid]
     return _enrich_pipeline(state, match[0])
+
+
+@router.put("/pipelines/reorder", status_code=204)
+async def reorder_pipelines(body: ReorderRequest, request: Request):
+    """Reorder pipelines by submitting full ordered list of IDs.
+    Body: { "pipeline_ids": ["id3", "id1", "id2"] }
+    sort_order is assigned sequentially (0, 1, 2, ...) based on position.
+    """
+    state = _get_state(request)
+    if not body.pipeline_ids:
+        raise HTTPException(status_code=400, detail="No pipeline_ids provided")
+    ok = pl.reorder_pipelines(state.db_con, body.pipeline_ids)
+    if not ok:
+        raise HTTPException(status_code=500, detail="Failed to reorder pipelines")
 
 
 @router.put("/pipelines/{pipeline_id}", response_model=PipelineResponse)
@@ -96,18 +112,6 @@ async def update_pipeline(pipeline_id: str, update: PipelineUpdate, request: Req
     if not match:
         raise HTTPException(status_code=404, detail="Pipeline not found")
     return _enrich_pipeline(state, match[0])
-
-
-@router.put("/pipelines/reorder", status_code=204)
-async def reorder_pipelines(body: dict, request: Request):
-    """Batch-update sort_order for pipelines.
-    Body: { "orders": { "pipeline_id": sort_order, ... } }
-    """
-    state = _get_state(request)
-    orders = body.get("orders", {})
-    if not orders:
-        raise HTTPException(status_code=400, detail="No orders provided")
-    pl.reorder_pipelines(state.db_con, orders)
 
 
 @router.delete("/pipelines/{pipeline_id}", status_code=204)

--- a/src/sortarr/api/routes/pipelines.py
+++ b/src/sortarr/api/routes/pipelines.py
@@ -98,6 +98,18 @@ async def update_pipeline(pipeline_id: str, update: PipelineUpdate, request: Req
     return _enrich_pipeline(state, match[0])
 
 
+@router.put("/pipelines/reorder", status_code=204)
+async def reorder_pipelines(body: dict, request: Request):
+    """Batch-update sort_order for pipelines.
+    Body: { "orders": { "pipeline_id": sort_order, ... } }
+    """
+    state = _get_state(request)
+    orders = body.get("orders", {})
+    if not orders:
+        raise HTTPException(status_code=400, detail="No orders provided")
+    pl.reorder_pipelines(state.db_con, orders)
+
+
 @router.delete("/pipelines/{pipeline_id}", status_code=204)
 async def delete_pipeline(pipeline_id: str, request: Request):
     state = _get_state(request)

--- a/src/sortarr/core/pipeline.py
+++ b/src/sortarr/core/pipeline.py
@@ -101,15 +101,21 @@ class PipelineOrchestrator:
 
     def _compute_published_after(self, sub) -> str:
         """Compute the earliest time we need data for this subscription
-        across all pipelines."""
-        min_ts = pl.get_min_tracking_for_subscription(self.db_con, sub.id)
-        candidates = []
+        in Phase 1 data collection.  Uses settings.published_after if set,
+        otherwise falls back to reprocess_days or 52 weeks.
+
+        NOTE: does NOT use per-subscription tracking (get_min_tracking_for_subscription)
+        because that can be pipeline-specific and prematurely narrow the lookback
+        window when multiple pipelines process the same subscription.
+        The per-pipeline freshness check (checkpoint 2.2) handles the reprocess
+        window separately."""
         if self.settings.published_after:
-            candidates.append(self.settings.published_after)
-        if min_ts:
-            candidates.append(min_ts)
-        if candidates:
-            return min(candidates)
+            return self.settings.published_after
+        if self.settings.reprocess_days > 0:
+            return (
+                datetime.now(timezone.utc)
+                - timedelta(days=self.settings.reprocess_days)
+            ).isoformat()
         return (datetime.now(timezone.utc) - timedelta(weeks=52)).isoformat()
 
     # ── Phase 2: Pipeline Processing ──────────────────────────────

--- a/src/sortarr/core/pipeline_runner.py
+++ b/src/sortarr/core/pipeline_runner.py
@@ -80,6 +80,7 @@ async def execute_pipeline(state, trigger="manual", dry_run=False, pipeline_id=N
                 subscription_scope=p["subscription_scope"],
                 destination_playlist_id=p["destination_playlist_id"],
                 destination_playlist_title=p["destination_playlist_title"],
+                sort_order=p["sort_order"],
                 created_at=p["created_at"],
                 updated_at=p["updated_at"],
             )

--- a/src/sortarr/db/migrations.py
+++ b/src/sortarr/db/migrations.py
@@ -245,6 +245,11 @@ CREATE TABLE IF NOT EXISTS playlist_video_tracking (
             con,
             "ALTER TABLE pipeline_runs ADD COLUMN pipeline_id TEXT",
         )
+        # V9: pipeline sort_order
+        _run_migration_safe(
+            con,
+            "ALTER TABLE pipelines ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0",
+        )
         con.commit()
         con.close()
         return True

--- a/src/sortarr/db/repository/pipeline.py
+++ b/src/sortarr/db/repository/pipeline.py
@@ -239,15 +239,13 @@ def get_min_tracking_for_subscription(
     return row["min_ts"] if row and row["min_ts"] else None
 
 
-def reorder_pipelines(con: sqlite3.Connection, orders: dict[str, int]) -> bool:
-    """Batch-update sort_order for pipelines. orders maps pipeline_id -> sort_order."""
+def reorder_pipelines(con: sqlite3.Connection, pipeline_ids: list[str]) -> bool:
+    """Assign sequential sort_order (0, 1, 2, ...) based on list position."""
+    now = datetime.now(timezone.utc).isoformat()
     try:
         con.executemany(
             "UPDATE pipelines SET sort_order = ?, updated_at = ? WHERE id = ?",
-            [
-                (order, datetime.now(timezone.utc).isoformat(), pid)
-                for pid, order in orders.items()
-            ],
+            [(idx, now, pid) for idx, pid in enumerate(pipeline_ids)],
         )
         con.commit()
         return True

--- a/src/sortarr/db/repository/pipeline.py
+++ b/src/sortarr/db/repository/pipeline.py
@@ -19,6 +19,7 @@ __all__ = [
     "get_pipeline_tracking",
     "upsert_pipeline_tracking",
     "get_min_tracking_for_subscription",
+    "reorder_pipelines",
     "get_routing_rules",
     "create_routing_rule",
     "update_routing_rule",
@@ -30,8 +31,8 @@ def get_pipelines(con: sqlite3.Connection) -> list[dict]:
     cursor = con.execute(
         "SELECT id, name, enabled, selector_mode, duration_min_seconds, duration_max_seconds, "
         "check_db_exists, check_title_similarity, compare_distance, subscription_scope, "
-        "destination_playlist_id, destination_playlist_title, created_at, updated_at "
-        "FROM pipelines ORDER BY name"
+        "destination_playlist_id, destination_playlist_title, created_at, updated_at, sort_order "
+        "FROM pipelines ORDER BY sort_order ASC, name ASC"
     )
     return [dict(row) for row in cursor.fetchall()]
 
@@ -52,12 +53,19 @@ def create_pipeline(
     check_sim = kwargs.get("check_title_similarity", 0)
     distance = kwargs.get("compare_distance", 80)
     scope = kwargs.get("subscription_scope", "all")
+    sort_order = kwargs.get("sort_order")
+    if sort_order is None:
+        # Default to max existing sort_order + 1
+        row = con.execute(
+            "SELECT COALESCE(MAX(sort_order), -1) + 1 AS next_order FROM pipelines"
+        ).fetchone()
+        sort_order = row["next_order"] if row else 0
     try:
         con.execute(
             "INSERT INTO pipelines (id, name, enabled, selector_mode, duration_min_seconds, duration_max_seconds, "
             "check_db_exists, check_title_similarity, compare_distance, subscription_scope, "
-            "destination_playlist_id, destination_playlist_title, created_at, updated_at) "
-            "VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "destination_playlist_id, destination_playlist_title, sort_order, created_at, updated_at) "
+            "VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 pipeline_id,
                 name,
@@ -70,6 +78,7 @@ def create_pipeline(
                 scope,
                 destination_playlist_id,
                 destination_playlist_title,
+                int(sort_order),
                 now,
                 now,
             ),
@@ -94,6 +103,7 @@ def update_pipeline(con: sqlite3.Connection, pipeline_id: str, **kwargs) -> bool
         "subscription_scope",
         "destination_playlist_id",
         "destination_playlist_title",
+        "sort_order",
     }
     updates = {k: v for k, v in kwargs.items() if k in allowed}
     if not updates:
@@ -227,6 +237,23 @@ def get_min_tracking_for_subscription(
     )
     row = cursor.fetchone()
     return row["min_ts"] if row and row["min_ts"] else None
+
+
+def reorder_pipelines(con: sqlite3.Connection, orders: dict[str, int]) -> bool:
+    """Batch-update sort_order for pipelines. orders maps pipeline_id -> sort_order."""
+    try:
+        con.executemany(
+            "UPDATE pipelines SET sort_order = ?, updated_at = ? WHERE id = ?",
+            [
+                (order, datetime.now(timezone.utc).isoformat(), pid)
+                for pid, order in orders.items()
+            ],
+        )
+        con.commit()
+        return True
+    except sqlite3.Error as err:
+        log.error("Failed to reorder pipelines: %s", err)
+        return False
 
 
 def get_routing_rules(con: sqlite3.Connection) -> list[dict]:

--- a/src/sortarr/models/pipeline.py
+++ b/src/sortarr/models/pipeline.py
@@ -65,6 +65,7 @@ class PipelineConfig:
     subscription_scope: str = "all"  # "all" | "selected"
     destination_playlist_id: str = ""
     destination_playlist_title: str = ""
+    sort_order: int = 0
     created_at: str = ""
     updated_at: str = ""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -74,6 +74,42 @@ def app():
             key TEXT PRIMARY KEY,
             value TEXT NOT NULL
         );
+        CREATE TABLE IF NOT EXISTS pipelines (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            enabled INTEGER NOT NULL DEFAULT 1,
+            selector_mode TEXT NOT NULL DEFAULT 'AND',
+            duration_min_seconds INTEGER NOT NULL DEFAULT 0,
+            duration_max_seconds INTEGER NOT NULL DEFAULT 0,
+            check_db_exists INTEGER NOT NULL DEFAULT 0,
+            check_title_similarity INTEGER NOT NULL DEFAULT 0,
+            compare_distance INTEGER NOT NULL DEFAULT 80,
+            subscription_scope TEXT NOT NULL DEFAULT 'all',
+            destination_playlist_id TEXT NOT NULL,
+            destination_playlist_title TEXT NOT NULL,
+            sort_order INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS pipeline_selectors (
+            id TEXT PRIMARY KEY,
+            pipeline_id TEXT NOT NULL REFERENCES pipelines(id) ON DELETE CASCADE,
+            field TEXT NOT NULL,
+            operator TEXT NOT NULL,
+            pattern TEXT NOT NULL,
+            combine_operator TEXT NOT NULL DEFAULT 'AND',
+            created_at TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS pipeline_subscriptions (
+            pipeline_id TEXT NOT NULL REFERENCES pipelines(id) ON DELETE CASCADE,
+            subscription_id TEXT NOT NULL,
+            PRIMARY KEY (pipeline_id, subscription_id)
+        );
+        CREATE TABLE IF NOT EXISTS pipeline_ignore_lists (
+            pipeline_id TEXT NOT NULL REFERENCES pipelines(id) ON DELETE CASCADE,
+            ignore_list_id TEXT NOT NULL,
+            PRIMARY KEY (pipeline_id, ignore_list_id)
+        );
     """)
     return app
 
@@ -105,3 +141,117 @@ async def test_rules_crud(app):
         resp = await client.get("/api/rules")
         assert resp.status_code == 200
         assert resp.json() == []
+
+
+# ── Pipeline sort_order & reorder tests ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_pipeline_with_sort_order(app):
+    """POST /pipelines with explicit sort_order should persist."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/pipelines",
+            json={
+                "name": "Ordered Pipeline",
+                "destination_playlist_id": "PL_test",
+                "sort_order": 5,
+            },
+        )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "Ordered Pipeline"
+    assert data["sort_order"] == 5
+
+
+@pytest.mark.asyncio
+async def test_get_pipelines_includes_sort_order(app):
+    """GET /pipelines response must include sort_order field."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # Create a pipeline first
+        await client.post(
+            "/api/pipelines",
+            json={
+                "name": "Pipe A",
+                "destination_playlist_id": "PL_a",
+            },
+        )
+        resp = await client.get("/api/pipelines")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    for p in data:
+        assert "sort_order" in p
+        assert isinstance(p["sort_order"], int)
+
+
+@pytest.mark.asyncio
+async def test_reorder_pipelines_valid(app):
+    """PUT /pipelines/reorder with valid pipeline_ids reorders correctly."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # Create 3 pipelines
+        ids = []
+        for name in ["Zeta", "Alpha", "Beta"]:
+            resp = await client.post(
+                "/api/pipelines",
+                json={"name": name, "destination_playlist_id": f"PL_{name}"},
+            )
+            assert resp.status_code == 201
+            ids.append(resp.json()["id"])
+
+        # Reorder: reverse the list
+        reversed_ids = list(reversed(ids))
+        resp = await client.put(
+            "/api/pipelines/reorder",
+            json={"pipeline_ids": reversed_ids},
+        )
+        assert resp.status_code == 204
+
+        # Verify order in GET response
+        resp = await client.get("/api/pipelines")
+        assert resp.status_code == 200
+        pipelines = resp.json()
+        # Filter to our test pipelines and sort by sort_order
+        our_pipelines = [p for p in pipelines if p["id"] in ids]
+        our_pipelines.sort(key=lambda p: p["sort_order"])
+        assert [p["id"] for p in our_pipelines] == reversed_ids
+
+
+@pytest.mark.asyncio
+async def test_reorder_pipelines_empty_list(app):
+    """PUT /pipelines/reorder with empty pipeline_ids should 400."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.put(
+            "/api/pipelines/reorder",
+            json={"pipeline_ids": []},
+        )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_reorder_pipelines_missing_field(app):
+    """PUT /pipelines/reorder with missing pipeline_ids should 422."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.put(
+            "/api/pipelines/reorder",
+            json={},
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_reorder_pipelines_invalid_type(app):
+    """PUT /pipelines/reorder with wrong type should 422."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.put(
+            "/api/pipelines/reorder",
+            json={"pipeline_ids": "not-a-list"},
+        )
+    assert resp.status_code == 422

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -19,6 +19,9 @@ from sortarr.db.repository.pipeline import (
     create_routing_rule,
     update_routing_rule,
     delete_routing_rule,
+    get_pipelines,
+    create_pipeline,
+    reorder_pipelines,
 )
 from sortarr.db.repository.pipeline_runs import (
     create_pipeline_run,
@@ -141,6 +144,90 @@ def test_app_config(db_con):
     assert get_config(db_con, "test_key") == "test_value"
     assert set_config(db_con, "test_key", "updated")
     assert get_config(db_con, "test_key") == "updated"
+
+
+# ── Pipeline sort_order / reorder tests ─────────────────────────────
+
+
+def test_create_pipeline_with_sort_order(db_con):
+    """create_pipeline with explicit sort_order should persist."""
+    assert create_pipeline(
+        db_con, "p_sort1", "Sorted", "PL_dest", "Dest", sort_order=42
+    )
+    pipelines = get_pipelines(db_con)
+    match = [p for p in pipelines if p["id"] == "p_sort1"]
+    assert len(match) == 1
+    assert match[0]["sort_order"] == 42
+
+
+def test_create_pipeline_auto_sort_order(db_con):
+    """create_pipeline without sort_order should auto-assign max+1."""
+    assert create_pipeline(db_con, "p_auto1", "First", "PL_dest", "Dest")
+    assert create_pipeline(db_con, "p_auto2", "Second", "PL_dest", "Dest")
+    pipelines = get_pipelines(db_con)
+    p1 = [p for p in pipelines if p["id"] == "p_auto1"][0]
+    p2 = [p for p in pipelines if p["id"] == "p_auto2"][0]
+    # Second gets sort_order=1 (max 0 + 1)
+    assert p2["sort_order"] == p1["sort_order"] + 1
+
+
+def test_get_pipelines_ordered_by_sort_order(db_con):
+    """get_pipelines should return pipelines ordered by sort_order ASC, name ASC."""
+    assert create_pipeline(db_con, "p_c", "C Pipe", "PL_dest", "Dest", sort_order=2)
+    assert create_pipeline(db_con, "p_a", "A Pipe", "PL_dest", "Dest", sort_order=0)
+    assert create_pipeline(db_con, "p_b", "B Pipe", "PL_dest", "Dest", sort_order=1)
+    pipelines = get_pipelines(db_con)
+    order = [p["sort_order"] for p in pipelines if p["id"].startswith("p_")]
+    assert order == sorted(order)
+
+
+def test_reorder_pipelines_happy_path(db_con):
+    """reorder_pipelines assigns sequential sort_order based on list position."""
+    assert create_pipeline(db_con, "r1", "R1", "PL_dest", "Dest")
+    assert create_pipeline(db_con, "r2", "R2", "PL_dest", "Dest")
+    assert create_pipeline(db_con, "r3", "R3", "PL_dest", "Dest")
+
+    assert reorder_pipelines(db_con, ["r3", "r1", "r2"])
+    pipelines = get_pipelines(db_con)
+    r1 = [p for p in pipelines if p["id"] == "r1"][0]
+    r2 = [p for p in pipelines if p["id"] == "r2"][0]
+    r3 = [p for p in pipelines if p["id"] == "r3"][0]
+    assert r3["sort_order"] == 0  # first in list
+    assert r1["sort_order"] == 1
+    assert r2["sort_order"] == 2
+
+
+def test_reorder_pipelines_non_existent_ids(db_con):
+    """reorder_pipelines with non-existent IDs should not raise."""
+    assert create_pipeline(db_con, "r_ex", "Exists", "PL_dest", "Dest")
+    # Should not fail even though "ghost" doesn't exist
+    assert reorder_pipelines(db_con, ["r_ex", "ghost"])
+    pipelines = get_pipelines(db_con)
+    r_ex = [p for p in pipelines if p["id"] == "r_ex"][0]
+    assert r_ex["sort_order"] == 0
+
+
+def test_reorder_pipelines_empty_list(db_con):
+    """reorder_pipelines with empty list should succeed (no-op)."""
+    assert create_pipeline(db_con, "r_empty", "EmptyTest", "PL_dest", "Dest")
+    assert reorder_pipelines(db_con, [])
+
+
+# ── PipelineConfig sort_order test ──────────────────────────────────
+
+
+def test_pipeline_config_construction_includes_sort_order():
+    """PipelineConfig construction from DB dict should include sort_order."""
+    from sortarr.models.pipeline import PipelineConfig
+
+    p = PipelineConfig(
+        id="test",
+        name="Test",
+        destination_playlist_id="PL_dest",
+        destination_playlist_title="Dest",
+        sort_order=7,
+    )
+    assert p.sort_order == 7
 
 
 def test_ignore_entries(db_con):

--- a/ui/index.html
+++ b/ui/index.html
@@ -1674,17 +1674,25 @@ renderers.pipelines = async function() {
     });
 
     // ── Reorder controls ─────────────────────────────────────
+    function swapAndSubmitReorder(idxA, idxB) {
+      // Swap the two positions in the pipelines array
+      const tmp = pipelines[idxA];
+      pipelines[idxA] = pipelines[idxB];
+      pipelines[idxB] = tmp;
+      // Send full ordered list to the backend
+      const pipeline_ids = pipelines.map(p => p.id);
+      api('/api/pipelines/reorder', {
+        method: 'PUT',
+        body: JSON.stringify({ pipeline_ids })
+      }).then(() => renderers.pipelines())
+        .catch(e => showToast('Reorder failed: ' + e.message, 'error'));
+    }
+
     document.querySelectorAll('.move-up-pipeline').forEach(btn => {
       btn.addEventListener('click', async function() {
         const idx = parseInt(this.dataset.idx);
         if (idx <= 0) return;
-        const orders = {};
-        orders[pipelines[idx].id] = pipelines[idx - 1].sort_order != null ? pipelines[idx - 1].sort_order : idx;
-        orders[pipelines[idx - 1].id] = pipelines[idx].sort_order != null ? pipelines[idx].sort_order : idx - 1;
-        try {
-          await api('/api/pipelines/reorder', { method: 'PUT', body: JSON.stringify({ orders }) });
-          renderers.pipelines();
-        } catch (e) { showToast('Reorder failed: ' + e.message, 'error'); }
+        swapAndSubmitReorder(idx, idx - 1);
       });
     });
 
@@ -1692,13 +1700,7 @@ renderers.pipelines = async function() {
       btn.addEventListener('click', async function() {
         const idx = parseInt(this.dataset.idx);
         if (idx >= pipelines.length - 1) return;
-        const orders = {};
-        orders[pipelines[idx].id] = pipelines[idx + 1].sort_order != null ? pipelines[idx + 1].sort_order : idx + 1;
-        orders[pipelines[idx + 1].id] = pipelines[idx].sort_order != null ? pipelines[idx].sort_order : idx;
-        try {
-          await api('/api/pipelines/reorder', { method: 'PUT', body: JSON.stringify({ orders }) });
-          renderers.pipelines();
-        } catch (e) { showToast('Reorder failed: ' + e.message, 'error'); }
+        swapAndSubmitReorder(idx, idx + 1);
       });
     });
   } catch { container.innerHTML = '<p class="error-state">Failed to load pipelines</p>'; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -1596,7 +1596,7 @@ renderers.pipelines = async function() {
     let allRuns = [];
     try { allRuns = await api('/api/pipeline/runs') || []; } catch {}
 
-    container.innerHTML = pipelines.map(p => {
+    container.innerHTML = pipelines.map((p, i) => {
       const pipelineRuns = allRuns.filter(r => r.pipeline_name === p.name || r.pipeline_id == p.id);
       const lastRun = pipelineRuns.length > 0 ? pipelineRuns[0].created_at : null;
       return `<div class="pipeline-card">
@@ -1614,6 +1614,9 @@ renderers.pipelines = async function() {
           <span>Selectors: ${(p.selectors || []).length}</span>
         </div>
         <div class="pipeline-card-actions">
+          <button class="move-up-pipeline btn btn-ghost btn-sm" data-pid="${p.id}" data-idx="${i}" title="Move up" style="font-size:0.9rem;padding:0 6px">&#9650;</button>
+          <button class="move-down-pipeline btn btn-ghost btn-sm" data-pid="${p.id}" data-idx="${i}" title="Move down" style="font-size:0.9rem;padding:0 6px">&#9660;</button>
+          <span style="color:var(--text-muted);font-size:0.75rem;display:flex;align-items:center">${p.sort_order != null ? p.sort_order : '-'}</span>
           <button class="trigger-pipeline btn btn-primary btn-sm" data-pid="${p.id}">&#9654; Run</button>
           <button class="dryrun-pipeline btn btn-secondary btn-sm" data-pid="${p.id}">&#9678; Dry Run</button>
           <button class="edit-pipeline btn btn-ghost btn-sm" data-pid="${p.id}">Edit</button>
@@ -1669,6 +1672,35 @@ renderers.pipelines = async function() {
         }
       });
     });
+
+    // ── Reorder controls ─────────────────────────────────────
+    document.querySelectorAll('.move-up-pipeline').forEach(btn => {
+      btn.addEventListener('click', async function() {
+        const idx = parseInt(this.dataset.idx);
+        if (idx <= 0) return;
+        const orders = {};
+        orders[pipelines[idx].id] = pipelines[idx - 1].sort_order != null ? pipelines[idx - 1].sort_order : idx;
+        orders[pipelines[idx - 1].id] = pipelines[idx].sort_order != null ? pipelines[idx].sort_order : idx - 1;
+        try {
+          await api('/api/pipelines/reorder', { method: 'PUT', body: JSON.stringify({ orders }) });
+          renderers.pipelines();
+        } catch (e) { showToast('Reorder failed: ' + e.message, 'error'); }
+      });
+    });
+
+    document.querySelectorAll('.move-down-pipeline').forEach(btn => {
+      btn.addEventListener('click', async function() {
+        const idx = parseInt(this.dataset.idx);
+        if (idx >= pipelines.length - 1) return;
+        const orders = {};
+        orders[pipelines[idx].id] = pipelines[idx + 1].sort_order != null ? pipelines[idx + 1].sort_order : idx + 1;
+        orders[pipelines[idx + 1].id] = pipelines[idx].sort_order != null ? pipelines[idx].sort_order : idx;
+        try {
+          await api('/api/pipelines/reorder', { method: 'PUT', body: JSON.stringify({ orders }) });
+          renderers.pipelines();
+        } catch (e) { showToast('Reorder failed: ' + e.message, 'error'); }
+      });
+    });
   } catch { container.innerHTML = '<p class="error-state">Failed to load pipelines</p>'; }
 };
 
@@ -1678,6 +1710,7 @@ function openPipelineModal(pipeline) {
   document.getElementById('pipelineId').value = pipeline ? pipeline.id : '';
   document.getElementById('pipelineName').value = pipeline ? pipeline.name : '';
   document.getElementById('pipelineScope').value = pipeline ? pipeline.subscription_scope : 'all';
+  window._editingPipeline = pipeline;
 
   // ── Subscription picker ─────────────────────────────────
   _selectedSubs = {};
@@ -1919,6 +1952,10 @@ document.getElementById('pipelineSave')?.addEventListener('click', async functio
     check_title_similarity: document.getElementById('pipelineCheckTitle').checked,
     compare_distance: parseInt(document.getElementById('pipelineDistance').value) || 80,
   };
+  // Preserve sort_order on update
+  if (id && window._editingPipeline && window._editingPipeline.sort_order != null) {
+    body.sort_order = window._editingPipeline.sort_order;
+  }
   try {
     let pipeline;
     if (id) {


### PR DESCRIPTION
## Root Cause

`_compute_published_after()` used `get_min_tracking_for_subscription()` which returns the `MIN(last_processed)` **across all pipelines** for a given subscription. When a broad-scope pipeline (e.g., "All to TBL") processed a subscription recently, this narrowed the YouTube API lookback window in Phase 1 to just hours, causing **zero activities** to be fetched for pipelines with narrower scopes (e.g., "Fireship").

## Fix

**`_compute_published_after()`** no longer uses `get_min_tracking_for_subscription()`. Phase 1 data collection now uses:
1. `settings.published_after` if set
2. `settings.reprocess_days` lookback if > 0
3. 52-week fallback

The per-pipeline freshness check at checkpoint 2.2 remains independent and unchanged.

## Pipeline Sorting

Added `sort_order` column to the `pipelines` table:

- **V9 migration**: `ALTER TABLE pipelines ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0`
- **get_pipelines()**: `ORDER BY sort_order ASC, name ASC`
- **create_pipeline()**: Auto-increments from `MAX(sort_order) + 1`
- **PUT /pipelines/reorder**: Accepts `{ "pipeline_ids": [...] }`, assigns sequential sort_order
- **UI**: ▲/▼ reorder buttons on pipeline cards, full-list submission on each swap

## Testing

- 131 tests pass (was 118)
- 14 new tests: reorder API happy path, validation, PipelineConfig sort_order, DB ordering

## Minor Items (not blocking)

- `get_min_tracking_for_subscription()` is now dead code — no callers remain. Can be removed in a follow-up.
- Reorder endpoint could validate duplicate pipeline_ids with a Pydantic validator.
- Frontend could restore array state on API failure for robustness.
- `reorder_pipelines()` could use explicit transaction rollback on DB error (extremely rare trigger).
- Reorder click handlers could await the async call for hygiene.