### PR TITLE
fix(ci): guard build job against empty release tag

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -30,6 +30,7 @@ jobs:
       release-enabled: true
       lint-enabled: false
   build:
+    if: ${{ needs.release.outputs.new-release-published == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       digest: ${{ steps.build_push.outputs.digest }}


### PR DESCRIPTION
The `build` job runs on every push to main, but `needs.release.outputs.git-tag` is empty when no new semantic-release version was published (e.g., a commit without `feat:` or `fix:` prefix). This causes the checkout step to fail with:

    pathspec refs/tags/ did not match any file(s) known to git

Added `if: needs.release.outputs.new-release-published == 'true'` to the `build` job, matching the pattern already used by the `deploy` job.