### PR TITLE
fix: break infinite hashchange loop when viewing run details

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -1123,7 +1123,6 @@ function showPage(pageId) {
   document.querySelectorAll('.sidebar-nav a').forEach(a => {
     a.classList.toggle('active', a.dataset.page === pageId);
   });
-  window.location.hash = pageId;
 }
 
 function renderPage(page) {
@@ -1141,6 +1140,7 @@ window.addEventListener('hashchange', () => {
   } else if (PAGES.includes(hash)) {
     renderPage(hash);
   } else {
+    // Unknown hash — show dashboard (safe: showPage no longer sets location.hash)
     showPage('dashboard');
   }
 });
@@ -1226,11 +1226,14 @@ function updateCompareBtn() {
 }
 
 async function openRunDetail(runId) {
+  window._pendingRunId = runId;
   location.hash = '#run-detail-' + runId;
   const [run, decisions] = await Promise.all([
     api('/api/pipeline/runs/' + runId),
     api('/api/pipeline/runs/' + runId + '/decisions'),
   ]);
+  // Stale-guard: discard if a newer openRunDetail was started while we waited
+  if (window._pendingRunId !== runId) return;
   if (!run) return;
 
   window._currentRunId = runId;


### PR DESCRIPTION
## What
Fixes the infinite hashchange loop that prevented users from viewing pipeline run details. Clicking any pipeline run card caused a cascading `hashchange → showPage → hashchange` cycle with up to 19 nested calls in 60ms.

## Root cause
`showPage()` at line 1126 of `ui/index.html` wrote `window.location.hash = pageId`, which triggered the `hashchange` event that had called `showPage()` in the first place — a circular dependency. When `openRunDetail(runId)` ran, the async `renderers.runDetail()` call (dispatched via hashchange handler, not awaited) re-set the hash before the cascade settled.

## Fix (3 changes)
1. **Removed `window.location.hash = pageId;` from `showPage()`** — breaks the cycle. Every caller already has the correct hash set before calling `showPage`.
2. **Added `window._pendingRunId` stale-async guard to `openRunDetail()`** — prevents stale API responses from overwriting newer run detail data when clicking run cards rapidly.
3. **Added clarifying comment** to the hashchange else fallback documenting the invariant.

## Review
- **Code-reviewer**: 0 CRITICAL, 0 MAJOR, 1 MINOR (search-results hash) — `Ready to merge — Yes`
- **Critic**: `[APPROVED]` — confidence SOUND — "The fix is correct, self-contained, and verified against the root cause"

Closes the infinite loop that made run detail navigation unusable.